### PR TITLE
Add a bool to driver_config for creating OM reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added an optimized offshore methanol production case to examples/03_methanol/co2_hydrogenation_doc
 - Updated setting up recorder in `PoseOptimization`
 - Added resource models to make solar resource API calls to the NREL Developer GOES dataset
+- Added `create_om_reports` option to driver config to enable/disable OpenMDAO reports (N2 diagrams, etc.)
 
 ## 0.4.0 [October 1, 2025]
 

--- a/h2integrate/core/h2integrate_model.py
+++ b/h2integrate/core/h2integrate_model.py
@@ -30,7 +30,9 @@ class H2IntegrateModel:
         # load custom models
         self.collect_custom_models()
 
-        self.prob = om.Problem()
+        # Check if create_om_reports is specified in driver config
+        create_om_reports = self.driver_config.get("general", {}).get("create_om_reports", True)
+        self.prob = om.Problem(reports=create_om_reports)
         self.model = self.prob.model
 
         # create site-level model

--- a/h2integrate/core/inputs/driver_schema.yaml
+++ b/h2integrate/core/inputs/driver_schema.yaml
@@ -17,6 +17,10 @@ properties:
         type: string
         description: Name of the folder for output files
         default: "output"
+      create_om_reports:
+        type: boolean
+        description: Whether to create OpenMDAO reports (N2 diagrams, etc.)
+        default: true
   driver:
     type: object
     properties:

--- a/h2integrate/core/test/conftest.py
+++ b/h2integrate/core/test/conftest.py
@@ -35,9 +35,10 @@ def pytest_sessionfinish(session, exitstatus):
         if file2path.exists():
             file2path.unlink()
         # remove folder created in h2integrate/core/test/test_recorder.py
-        files_in_test_folder = list(test_dir.iterdir())
-        if len(files_in_test_folder) == 0:
-            test_dir.rmdir()
+        if test_dir.exists():
+            files_in_test_folder = list(test_dir.iterdir())
+            if len(files_in_test_folder) == 0:
+                test_dir.rmdir()
 
         # remove environment variables used for tests in
         # h2integrate/core/test/test_recorder.py

--- a/h2integrate/core/test/test_framework.py
+++ b/h2integrate/core/test/test_framework.py
@@ -147,15 +147,20 @@ def test_unsupported_simulation_parameters():
 
 
 def test_technology_connections():
+    original_cwd = Path.cwd()
     os.chdir(examples_dir / "01_onshore_steel_mn")
 
-    # Path to the original plant_config.yaml and high-level yaml in the example directory
+    # Path to the original plant_config.yaml, driver_config.yaml and high-level yaml
+    # in the example directory
     orig_plant_config = Path.cwd() / "plant_config.yaml"
     temp_plant_config = Path.cwd() / "temp_plant_config.yaml"
+    orig_driver_config = Path.cwd() / "driver_config.yaml"
+    temp_driver_config = Path.cwd() / "temp_driver_config.yaml"
     orig_highlevel_yaml = Path.cwd() / "01_onshore_steel_mn.yaml"
     temp_highlevel_yaml = Path.cwd() / "temp_01_onshore_steel_mn.yaml"
 
     shutil.copy(orig_plant_config, temp_plant_config)
+    shutil.copy(orig_driver_config, temp_driver_config)
     shutil.copy(orig_highlevel_yaml, temp_highlevel_yaml)
 
     # Load the plant_config YAML content
@@ -169,28 +174,57 @@ def test_technology_connections():
     )
     plant_config_data["technology_interconnections"] = new_tech_interconnections
 
-    # Save the modified tech_config YAML back
+    # Save the modified plant_config YAML back
     with temp_plant_config.open("w") as f:
         yaml.safe_dump(plant_config_data, f)
+
+    # Load the driver config and set create_om_reports to False to test report suppression
+    with temp_driver_config.open() as f:
+        driver_data = yaml.safe_load(f)
+
+    if "general" not in driver_data:
+        driver_data["general"] = {}
+    driver_data["general"]["create_om_reports"] = False
+
+    # Save the modified driver config
+    with temp_driver_config.open("w") as f:
+        yaml.safe_dump(driver_data, f)
 
     # Load the high-level YAML content
     with temp_highlevel_yaml.open() as f:
         highlevel_data = yaml.safe_load(f)
 
-    # Modify the high-level YAML to point to the temp tech_config file
+    # Modify the high-level YAML to point to the temp config files
     highlevel_data["plant_config"] = str(temp_plant_config.name)
+    highlevel_data["driver_config"] = str(temp_driver_config.name)
 
     # Save the modified high-level YAML back
     with temp_highlevel_yaml.open("w") as f:
         yaml.safe_dump(highlevel_data, f)
 
-    h2i_model = H2IntegrateModel(temp_highlevel_yaml)
+    # Record initial files before running the model
+    initial_files = set(Path.cwd().rglob("*"))
 
+    h2i_model = H2IntegrateModel(temp_highlevel_yaml)
     h2i_model.run()
+
+    # Check that no OpenMDAO report directories were created
+    final_files = set(Path.cwd().rglob("*"))
+    new_files = final_files - initial_files
+    report_dirs = [f for f in new_files if f.is_dir() and "reports" in f.name.lower()]
+
+    # Assert that no report directories were created due to create_om_reports=False
+    assert (
+        len(report_dirs) == 0
+    ), f"Report directories were created despite create_om_reports=False: {report_dirs}"
 
     # Clean up temporary YAML files
     temp_plant_config.unlink(missing_ok=True)
+    temp_driver_config.unlink(missing_ok=True)
     temp_highlevel_yaml.unlink(missing_ok=True)
+
+    # Restore original working directory
+    os.chdir(original_cwd)
 
 
 def test_resource_connection_error_missing_connection():


### PR DESCRIPTION
# Add a bool to driver_config for creating OM reports

Useful for running a lot of cases quickly without producing reports.
Defaults to True.
Originally suggested by @elenya-grant.

## Type of Contribution
<!-- Check all that apply to help reviewers understand your contribution -->
- [x] Feature Enhancement
  - [ ] New Technology Model
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] CI Changes
- [ ] Other (please describe):

## General PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [-] Documentation
  - [-] Docstrings are up-to-date
  - [-] Related `docs/` files are up-to-date, or added when necessary
  - [-] Documentation has been rebuilt successfully
  - [-] Examples have been updated (if applicable)
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] Added tests for new functionality or bug fixes
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## New Technology Checklist
<!-- Complete this section only if you checked "New Technology Model" above -->
- [ ] **Performance Model**: Technology performance model has been implemented and follows H2Integrate patterns (if applicable)
- [ ] **Cost Model**: Technology cost model has been implemented (if applicable)
- [ ] **Tests**: Unit tests have been added for the new technology
  - [ ] Performance model tests (if applicable)
  - [ ] Cost model tests (if applicable)
  - [ ] Integration tests with H2Integrate system
- [ ] **Example**: A working example demonstrating the new technology has been created
  - [ ] Example has been tested and runs successfully in `test_all_examples.py`
  - [ ] Example is documented with clear explanations in `examples/README.md`
    - [ ] Input file comments
    - [ ] Run file comments
- [ ] **Documentation**:
  - [ ] Technology documentation page added to `docs/technology_models/`
  - [ ] Technology added to the main technology models list in `docs/technology_models/technology_overview.md`
- [ ] **Integration**: Technology has been properly integrated into H2Integrate
  - [ ] Added to `supported_models.py`
  - [ ] If a new commodity_type is added, update `create_financial_model` in `h2integrate_model.py`
  - [ ] Follows established naming conventions outlined in `docs/developer_guide/coding_guidelines.md`

## Related issues

<!--If one exists, link to a related GitHub Issue.-->


## Impacted areas of the software

## Additional supporting information

<!--Add any other context about the problem here.-->


## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->


<!--
__ For NREL use __
Release checklist:
- [ ] Update the version in h2integrate/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NREL/H2Integrate repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
