### PR TITLE
Improve readability of postprocessing output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Added ability for latitude and longitude to be design variables in design sweep
 - Move geologic hydrogen models into specific geoh2 subsurface converters
 - Added standalone iron mine performance and cost model
+- Improved readability of the postprocessing printout by simplifying numerical representation, especially for years
 
 ## 0.4.0 [October 1, 2025]
 

--- a/h2integrate/core/utilities.py
+++ b/h2integrate/core/utilities.py
@@ -811,10 +811,25 @@ def print_results(model, includes=None, excludes=None, show_units=True):
             mean_raw = _mean(meta.get("val"))
             try:
                 val = float(mean_raw)
-                if abs(val) >= 1e5:
-                    mean_val = f"{val:,.2f}"
+                units_val_raw = meta.get("units")
+                # Format as integer if units are 'year' or variable name is 'cost_year'
+                if units_val_raw == "year" or var == "cost_year":
+                    mean_val = str(int(val))
+                elif abs(val) >= 1e5:
+                    formatted = f"{val:,.2f}"
+                    mean_val = formatted.rstrip("0")
+                    if mean_val.endswith("."):
+                        mean_val = mean_val  # Keep e.g. "520." format
+                    else:
+                        mean_val = mean_val + "." if "." not in mean_val else mean_val
                 else:
-                    mean_val = f"{val:,.4f}"
+                    formatted = f"{val:,.4f}"
+                    mean_val = formatted.rstrip("0")
+                    # Ensure we end with "." if all decimals were zeros
+                    if mean_val.endswith("."):
+                        pass  # Keep as e.g. "520." or "0."
+                    elif "." not in mean_val:
+                        mean_val = mean_val + "."
             except (ValueError, TypeError):
                 mean_val = str(mean_raw)
             units_val = (


### PR DESCRIPTION
# Improve readability of postprocessing output

Prettified parts of the postprocessing output:
- made years appear as integers
- made e.g. `520.000` appears as `520.` for simplicity

Here's what it looks like now:
```
     singlitico_electrolyzer_cost              │                  │           │       │
       CapEx                                   │   487,835,175.51 │ USD       │ 1     │ electrolyzer.CapEx
       OpEx                                    │    11,946,313.76 │ USD/year  │ 1     │ electrolyzer.OpEx
       VarOpEx                                 │               0. │ USD/year  │ 30    │ electrolyzer.VarOpEx
       cost_year                               │             2021 │ n/a       │ n/a   │ electrolyzer.cost_year
```

## Type of Contribution
<!-- Check all that apply to help reviewers understand your contribution -->
- [ ] Feature Enhancement
  - [ ] New Technology Model
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] CI Changes
- [x] Other (please describe): code cleanup

## General PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [-] Documentation
  - [-] Docstrings are up-to-date
  - [-] Related `docs/` files are up-to-date, or added when necessary
  - [-] Documentation has been rebuilt successfully
  - [-] Examples have been updated (if applicable)
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [-] Added tests for new functionality or bug fixes
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

Resolves #373 
