### PR TITLE
Enable override of maximum number of turbines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased [TBD]
-
+- Enable `PySAMWindPlantPerformanceModel` to accept more than 300 turbines by overriding the default maximum in the PySAM model. [PR 831](https://github.com/NatLabRockies/H2Integrate/pull/831)
 - Add `PySAMWavePerformanceModel` and `WaveResource` to wrap PySAM MhkWave as an H2I performance model, replacing the HOPP wave module in example 09. [PR 825](https://github.com/NatLabRockies/H2Integrate/pull/825)
 
 ## 0.9 [August 10, 2026]

--- a/docs/technology_models/windpower_wind_plant.md
+++ b/docs/technology_models/windpower_wind_plant.md
@@ -44,7 +44,7 @@ technologies:
 
 (windpower-performance-parameters)=
 ## Performance Parameters
-- `num_turbines` (required): number of wind turbines in the wind farm
+- `num_turbines` (required): number of wind turbines in the wind farm. Previously limited to 300 turbines, but this limit has been removed in the latest version.
 - `hub_height` (required): wind turbine hub height in meters
 - `rotor_diameter` (required): wind turbine rotor diameter in meters
 - `turbine_rating_kw` (required): rated power of individual wind turbine in kW

--- a/h2integrate/converters/wind/test/test_pysam_wind.py
+++ b/h2integrate/converters/wind/test/test_pysam_wind.py
@@ -357,3 +357,18 @@ def test_wind_plant_pysam_change_n_turbines(plant_config_wtk, wind_plant_config,
             )
             == 2027210.444644157
         )
+
+    # Set a number of turbines exceeding the previous 300-turbine limit
+    new_num_turbines = 400
+    prob.set_val("wind_plant.num_turbines", new_num_turbines)
+    prob.run_model()
+
+    expected_farm_capacity_MW = new_num_turbines * wind_plant_config["turbine_rating_kw"] / 1e3
+
+    with subtests.test("wind farm capacity with >300 turbines"):
+        assert (
+            pytest.approx(
+                prob.get_val("wind_plant.rated_electricity_production", units="MW")[0], rel=1e-6
+            )
+            == expected_farm_capacity_MW
+        )

--- a/h2integrate/converters/wind/wind_pysam.py
+++ b/h2integrate/converters/wind/wind_pysam.py
@@ -484,6 +484,10 @@ class PYSAMWindPlantPerformanceModel(WindPerformanceBaseClass):
                 self.system_model.value("wind_turbine_rotor_diameter"), n_turbs, self.layout_config
             )
 
+        # Override the 300-turbine maximum, if needed
+        if n_turbs > 300:
+            self.system_model.value("max_turbine_override", n_turbs)
+
         self.system_model.value("wind_farm_xCoordinates", tuple(x_pos))
         self.system_model.value("wind_farm_yCoordinates", tuple(y_pos))
 


### PR DESCRIPTION
# Enable users to set arbitrary number of turbines in PySAM wind model

By default, SAM limits users to 300 wind turbines. However, an override variable was [introduced to PySAM in 2021](https://github.com/NatLabRockies/ssc/pull/656) to enable users to circumvent this limit in the SAM wake models. Using this capability, and following a suggestion from @bayc, this PR makes a very minor change to the `PySAMWindPlantPerformanceModel` to override the 300-turbine limit.

## Section 1: Type of Contribution
<!-- Check all that apply to help reviewers understand your contribution -->
- [x] Feature Enhancement
  - [ ] Framework
  - [ ] New Model
  - [x] Updated Model
  - [ ] Tools/Utilities
  - [ ] Other (please describe):
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] CI Changes
- [ ] Other (please describe):

## Section 2: Draft PR Checklist
<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
<!--Complete when opening a draft PR. -->
- [x] Open draft PR
- [x] Describe the feature that will be added
- [x] Fill out TODO list steps
- [x] Describe requested feedback from reviewers on draft PR
- [x] Complete Section 8: New Model Checklist (if applicable)
<!-- Describe the feature in this PR and outline next steps -->
### TODO:
- [x] Ensure existing tests pass as expected
- [x] Add new test
- [x] Check if changes are needed to the H2Integrate documentation and update if needed

### Type of Reviewer Feedback Requested (on Draft PR)
<!-- Outline the feedback that would be helpful from reviewers while it's a draft PR -->
To see how this change works, I suggest running the 05_wind_h2_opt example.

- First, run (`python run_wind_electrolyzer.py`) on the `develop` branch as configured with 50 turbines: the example runs to completion
- Next, change `num_turbines` from `50` to `305` in 05_wind_h2_opt/tech_config.yaml. Rerun the python runscript. The following error is raised:
```
Exception: 'plant.wind.PYSAMWindPlantPerformanceModel' <class PYSAMWindPlantPerformanceModel>: Error calling compute(), windpower execution error.
        exec fail(windpower): the wind model is only configured to handle up to 300 turbines
```
- Finally, switch to the feature branch (`feature/max-turbs`) and rerun the example (with `num_turbines` still set to `305`). See that the example now runs to completion.

## Section 3: General PR Checklist
<!--Complete when converting draft PR to a merge-ready PR. -->
- [x] PR description thoroughly describes the new feature, bug fix, etc.
- [x] Added tests for new functionality or bug fixes
- [x] Tests pass (If not, and this is expected, please elaborate in the Section 6: Test Results)
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [x] ~Examples have been updated (if applicable)~ [NA]
- [x] `CHANGELOG.md`
  - [x] At least one complete sentence has been provided to describe the changes made in this PR
  - [x] After the above, a hyperlink has been provided to the PR using the following format:
    "A complete thought. [PR XYZ]((https://github.com/NatLabRockies/H2Integrate/pull/XYZ)", where
    `XYZ` should be replaced with the actual number.

## Section 4: Related Issues
- None



## Section 5: Impacted Areas of the Software

### Section 5.1: New Files
- NA

### Section 5.2: Modified Files
- `h2integrate/converters/wind/wind_pysam.py`
  - `PYSAMWindPlantPerformanceModel.compute()`: Now alters the turbine limit if the user specifies greater than 300 turbines.
- h2integrate/converters/wind/test/test_pysam_wind.py
- docs/technology_models/windpower_wind_plant.md
- CHANGELOG.md

## Section 6: Additional Supporting Information
- Using the "Simple" wake model in PySAM, which is the default, the runtime of `PySAM.Windpower.execute()` appears to scale roughly linearly with the number of wind turbines.

## Section 7: Test Results, if applicable
- New test added to h2integrate/converters/wind/test/test_pysam_wind.py that runs a PySAM model with 400 turbines. The test passes on the new feature branch, but fails on `develop`, as expected.






<!--
__ For NLR use __
Release checklist:
- [ ] Update the version in h2integrate/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NatLabRockies/H2Integrate repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
