### PR TITLE
Added automerge enabled to CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - ready_for_review
       - review_requested
       - enqueued
+      - auto_merge_enabled
     paths:
       - h2integrate/**.py
   schedule:


### PR DESCRIPTION
# Enabled automerge trigger for CI

A reasonable assumption would be that if `automerge` is enabled for a PR, we'd want the full test suite to be run again.
This PR changes that to be true.