### PR TITLE
Allow demand components as non-topology-constraining destinations in technology interconnections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed error message that is thrown in `check_inputs` and updated testing of `check_inputs` to actually test the error messages [PR #846](https://github.com/NatLabRockies/H2Integrate/pull/846)
 - Fixed several tests where the assert statements paired with `pytest.raises` were indented inside the context manager block and never ran, and corrected the now-active expected error strings. [PR #846](https://github.com/NatLabRockies/H2Integrate/pull/846)
 - Replaces all custom attrs validators in `h2integrate.core.validators` with built in attrs validators. [PR 835](https://github.com/NatLabRockies/H2Integrate/pull/835)
+- Exempted demand components from the tech interconnections checking, added unit test. [PR 850](https://github.com/NatLabRockies/H2Integrate/pull/850)
 
 ## 0.9 [August 10, 2026]
 

--- a/h2integrate/core/h2integrate_model.py
+++ b/h2integrate/core/h2integrate_model.py
@@ -2396,6 +2396,66 @@ class H2IntegrateModel:
                         f"send it to at most 1. Consider using a splitter component."
                     )
 
+        # --- Check 4: prevent commodity double-counting via demand components ---
+        # A demand component may receive a commodity and pass it on to a real consumer
+        # (e.g. acting as a profile regularizer). However, if a source does this it
+        # must NOT also send the same commodity directly to another real consumer,
+        # because the flow would be counted twice.
+        #
+        # Valid:   source -> demand_comp -> real_consumer   (single path through demand)
+        # Valid:   source -> demand_comp (pure observer)
+        #          source -> real_consumer
+        # Invalid: source -> real_consumer_A                (competing direct path)
+        #          source -> demand_comp -> real_consumer_B (and also via demand)
+        #
+        # The check is transitive: a demand component "reaches a real consumer" even
+        # when the path passes through a chain of other demand components first.
+
+        def _demand_reaches_real_consumer(demand_tech: str) -> bool:
+            """Return True if demand_tech can reach a non-demand tech via L4 edges."""
+            visited: set[str] = set()
+            stack = [demand_tech]
+            while stack:
+                node = stack.pop()
+                if node in visited:
+                    continue
+                visited.add(node)
+                for _, d, c in self.technology_graph.out_edges(node, data="commodity"):
+                    if not c:
+                        continue
+                    if self.tech_control_classifiers.get(d) != "demand":
+                        return True
+                    stack.append(d)
+            return False
+
+        # Build per-(source, commodity) destination lists from L4 edges.
+        source_commodity_dests: dict[tuple[str, str], list[str]] = {}
+        for source, dest, commodity in self.technology_graph.edges(data="commodity"):
+            if not commodity:
+                continue
+            for c in commodity:
+                source_commodity_dests.setdefault((source, c), []).append(dest)
+
+        for (source, commodity), dests in source_commodity_dests.items():
+            direct_real_dests = [
+                d for d in dests if self.tech_control_classifiers.get(d) != "demand"
+            ]
+            outputting_demand_dests = [
+                d
+                for d in dests
+                if self.tech_control_classifiers.get(d) == "demand"
+                and _demand_reaches_real_consumer(d)
+            ]
+            if direct_real_dests and outputting_demand_dests:
+                raise ValueError(
+                    f"Technology {source!r} sends commodity {commodity!r} both directly "
+                    f"to {direct_real_dests} and to demand component(s) "
+                    f"{outputting_demand_dests} that re-emit the commodity to real "
+                    f"consumers. This would double-count the commodity flow. Either route "
+                    f"all {commodity!r} from {source!r} through the demand component, or "
+                    f"connect the downstream consumers directly to {source!r} instead."
+                )
+
     def _check_tech_connections(self):
         """Check that commodity streams between technologies are valid.
 

--- a/h2integrate/core/h2integrate_model.py
+++ b/h2integrate/core/h2integrate_model.py
@@ -2302,13 +2302,19 @@ class H2IntegrateModel:
                 continue  # length-3 connections carry no commodity; skip them
             out_degs_l4[source] = out_degs_l4.get(source, 0) + 1
             in_degs_l4[dest] = in_degs_l4.get(dest, 0) + 1
+            dest_classifier = self.tech_control_classifiers.get(dest)
             for c in commodity:
                 in_commodity_sources.setdefault(dest, {}).update(
                     {c: in_commodity_sources.get(dest, {}).get(c, 0) + 1}
                 )
-                out_commodity_dests.setdefault(source, {}).update(
-                    {c: out_commodity_dests.get(source, {}).get(c, 0) + 1}
-                )
+                # Demand-classified techs are observers/sinks (they report on a commodity
+                # stream but do not consume it in a topology sense). Exclude them from the
+                # source's output-destination count so that a source may simultaneously
+                # feed a real consumer and a reporting/demand component without triggering
+                # the multi-destination error in Check 3.
+                if dest_classifier != "demand":
+                    current = out_commodity_dests.setdefault(source, {})
+                    current[c] = current.get(c, 0) + 1
 
         # --- Check 2: storage technology topology ---
         storage_techs = [k for k, v in self.tech_control_classifiers.items() if v == "storage"]

--- a/h2integrate/core/test/test_framework.py
+++ b/h2integrate/core/test/test_framework.py
@@ -509,6 +509,87 @@ def test_validate_interconnections_demand_component_not_counted_as_destination(s
         assert "wind" in err
         assert "Consider using a splitter component." in err
 
+    # Sending to a demand component that re-emits to a real consumer is valid on its
+    # own; wind routes all electricity through the demand component to grid_sell.
+    interconnections_demand_passthrough = [
+        ["wind", "demand_comp", "electricity", "cable"],
+        ["demand_comp", "grid_sell", "electricity", "cable"],
+    ]
+    classifiers_demand_passthrough = {
+        "wind": "flexible",
+        "demand_comp": "demand",
+        "grid_sell": "dispatchable",
+    }
+    fake_passthrough = _make_fake_model(
+        interconnections_demand_passthrough, classifiers_demand_passthrough
+    )
+
+    with subtests.test("demand component acting as pass-through to real consumer passes"):
+        H2IntegrateModel._validate_technology_interconnections(fake_passthrough)  # must not raise
+
+    # Double-counting: wind sends electricity to electrolyzer directly AND through a
+    # demand component to grid_sell. The same electricity is counted in both paths.
+    interconnections_double_count = [
+        ["wind", "electrolyzer", "electricity", "cable"],
+        ["wind", "demand_reporter", "electricity", "cable"],
+        ["demand_reporter", "grid_sell", "electricity", "cable"],
+    ]
+    classifiers_double_count = {
+        "wind": "flexible",
+        "electrolyzer": "dispatchable",
+        "demand_reporter": "demand",
+        "grid_sell": "dispatchable",
+    }
+    fake_double_count = _make_fake_model(interconnections_double_count, classifiers_double_count)
+
+    with subtests.test("source to direct real consumer AND outputting demand raises error"):
+        with pytest.raises(ValueError) as excinfo:
+            H2IntegrateModel._validate_technology_interconnections(fake_double_count)
+        err = str(excinfo.value)
+        assert "wind" in err
+        assert "double-count" in err
+
+    # Daisy-chain through two demand components then to a real consumer is valid as
+    # long as wind does not also have a competing direct path to a real consumer.
+    interconnections_daisy_valid = [
+        ["wind", "demand_reporter", "electricity", "cable"],
+        ["demand_reporter", "nested_demand", "electricity", "cable"],
+        ["nested_demand", "grid_sell", "electricity", "cable"],
+    ]
+    classifiers_daisy_valid = {
+        "wind": "flexible",
+        "demand_reporter": "demand",
+        "nested_demand": "demand",
+        "grid_sell": "dispatchable",
+    }
+    fake_daisy_valid = _make_fake_model(interconnections_daisy_valid, classifiers_daisy_valid)
+
+    with subtests.test("daisy-chained demand components as sole path to real consumer passes"):
+        H2IntegrateModel._validate_technology_interconnections(fake_daisy_valid)  # must not raise
+
+    # Same daisy-chain but wind also has a direct real consumer - should fail.
+    interconnections_daisy_double = [
+        ["wind", "electrolyzer", "electricity", "cable"],
+        ["wind", "demand_reporter", "electricity", "cable"],
+        ["demand_reporter", "nested_demand", "electricity", "cable"],
+        ["nested_demand", "grid_sell", "electricity", "cable"],
+    ]
+    classifiers_daisy_double = {
+        "wind": "flexible",
+        "electrolyzer": "dispatchable",
+        "demand_reporter": "demand",
+        "nested_demand": "demand",
+        "grid_sell": "dispatchable",
+    }
+    fake_daisy_double = _make_fake_model(interconnections_daisy_double, classifiers_daisy_double)
+
+    with subtests.test("daisy-chained demand with competing direct path raises error"):
+        with pytest.raises(ValueError) as excinfo:
+            H2IntegrateModel._validate_technology_interconnections(fake_daisy_double)
+        err = str(excinfo.value)
+        assert "wind" in err
+        assert "double-count" in err
+
 
 @pytest.mark.unit
 @pytest.mark.parametrize(

--- a/h2integrate/core/test/test_framework.py
+++ b/h2integrate/core/test/test_framework.py
@@ -463,6 +463,54 @@ def test_validate_interconnections_length3_commodity_pair_with_slices_raises(sub
 
 
 @pytest.mark.unit
+def test_validate_interconnections_demand_component_not_counted_as_destination(subtests):
+    """A source sending a commodity to both a real consumer and a demand-classified
+    reporting component must pass validation.
+
+    Demand components are observers/sinks that report on a commodity stream
+    but do not consume it in a topology sense. They should not count against
+    the source's per-commodity output-destination limit, allowing a pattern like:
+
+        wind -> electricity -> electrolyzer   (real consumer)
+        wind -> electricity -> demand_reporter (reporting only)
+
+    The two-real-consumer case (no demand component involved) must still fail.
+    """
+    interconnections_valid = [
+        ["wind", "electrolyzer", "electricity", "cable"],
+        ["wind", "demand_reporter", "electricity", "cable"],
+    ]
+    classifiers_valid = {
+        "wind": "flexible",
+        "electrolyzer": "dispatchable",
+        "demand_reporter": "demand",
+    }
+    fake_valid = _make_fake_model(interconnections_valid, classifiers_valid)
+
+    with subtests.test("source to real consumer + demand reporter passes validation"):
+        H2IntegrateModel._validate_technology_interconnections(fake_valid)  # must not raise
+
+    # Two real (non-demand) consumers of the same commodity from one source must still fail.
+    interconnections_bad = [
+        ["wind", "electrolyzer", "electricity", "cable"],
+        ["wind", "grid", "electricity", "cable"],
+    ]
+    classifiers_bad = {
+        "wind": "flexible",
+        "electrolyzer": "dispatchable",
+        "grid": "dispatchable",
+    }
+    fake_bad = _make_fake_model(interconnections_bad, classifiers_bad)
+
+    with subtests.test("source to two real consumers still raises error"):
+        with pytest.raises(ValueError) as excinfo:
+            H2IntegrateModel._validate_technology_interconnections(fake_bad)
+        err = str(excinfo.value)
+        assert "wind" in err
+        assert "Consider using a splitter component." in err
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "example_folder,resource_example_folder", [("07_run_of_river_plant", None)]
 )


### PR DESCRIPTION
# Allow demand components as non-topology-constraining destinations in technology interconnections

1. Demand-classified components (subclasses of `DemandComponentBase`) are now exempt from the per-commodity output-destination count in `_validate_technology_interconnections`
2. Added a unit test to cover the valid case and confirm the two-real-consumer error is still raised.

## Section 1: Type of Contribution
- [x] Feature Enhancement
  - [x] Framework

## Section 2: Draft PR Checklist
N/A - not a draft PR.

## Section 3: General PR Checklist
- [x] PR description thoroughly describes the new feature, bug fix, etc.
- [x] Added tests for new functionality or bug fixes
- [x] Tests pass
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [ ] Related `docs/` files are up-to-date, or added when necessary
  - [ ] Documentation has been rebuilt successfully
  - [ ] Examples have been updated (if applicable)
- [x] `CHANGELOG.md`
  - [x] At least one complete sentence has been provided to describe the changes made in this PR
  - [x] After the above, a hyperlink has been provided to the PR

## Section 4: Related Issues

N/A

## Section 5: Impacted Areas of the Software

### Section 5.1: New Files

N/A

### Section 5.2: Modified Files
- `h2integrate/core/h2integrate_model.py`
  - `_validate_technology_interconnections`: Skip demand-classified destinations when building `out_commodity_dests` so they do not count against the source's per-commodity output limit.
- `h2integrate/core/test/test_framework.py`
  - `test_validate_interconnections_demand_component_not_counted_as_destination`: New unit test covering valid source-to-consumer-plus-demand-reporter topology and confirming the two-real-consumer error is unchanged.

## Section 6: Additional Supporting Information

N/A

## Section 7: Test Results, if applicable

New unit test passes. Existing unit tests for `_validate_technology_interconnections` are unaffected.
