### PR TITLE
Re-organization of Resource Model Inheritance

### DIFF
--- a/docs/user_guide/defining_sites_and_resources.md
+++ b/docs/user_guide/defining_sites_and_resources.md
@@ -19,7 +19,6 @@ sites:
         resource_model: "wind_toolkit_v2_api"
         resource_parameters:
           resource_year: 2012
-          use_fixed_resource_location: True # this is the default
 ```
 
 Further information on the available resource models can be found [here](https://h2integrate.readthedocs.io/en/latest/resource/resource_index.html)
@@ -76,7 +75,6 @@ sites:
         resource_model: "wind_toolkit_v2_api"
         resource_parameters:
           resource_year: 2012
-          use_fixed_resource_location: True
 resource_to_tech_connections: [
   # formatted as [site_name.resource_name, tech_name, variable_name],
   ['wind_site.wind_resource', 'wind', 'wind_resource_data'],
@@ -103,12 +101,10 @@ sites:
         resource_model: "wind_toolkit_v2_api"
         resource_parameters:
           resource_year: 2012
-          use_fixed_resource_location: True
       solar_resource: #resource model name for solar resource
         resource_model: "goes_aggregated_solar_v4_api"
         resource_parameters:
           resource_year: 2012
-          use_fixed_resource_location: True
 resource_to_tech_connections: [
   # formatted as [site_name.resource_name, tech_name, variable_name],
   ['site_A.wind_resource', 'wind', 'wind_resource_data'],

--- a/examples/22_site_doe/plant_config.yaml
+++ b/examples/22_site_doe/plant_config.yaml
@@ -9,7 +9,6 @@ sites:
         resource_model: GOESAggregatedSolarAPI
         resource_parameters:
           resource_year: 2012
-          use_fixed_resource_location: false  # set to False since sweeping sites
 resource_to_tech_connections:
   # connect the solar resource to the solar technology
   - [site.solar_resource, solar, solar_resource_data]

--- a/examples/27_site_doe_diff/plant_config.yaml
+++ b/examples/27_site_doe_diff/plant_config.yaml
@@ -9,7 +9,6 @@ sites:
         resource_model: WTKNLRDeveloperAPIWindResource
         resource_parameters:
           resource_year: 2012
-          use_fixed_resource_location: false  # set to False so the resource data is updated when the site location changes in the design sweep
   solar_site:  # name of the site for the solar technology
     latitude: 34.22
     longitude: -102.75
@@ -18,7 +17,6 @@ sites:
         resource_model: GOESAggregatedSolarAPI
         resource_parameters:
           resource_year: 2012
-          use_fixed_resource_location: false  # set to False so the resource data is updated when the site location changes in the design sweep
 resource_to_tech_connections:
   # connect the wind resource to the wind technology
   - [wind_site.wind_resource, wind, wind_resource_data]

--- a/h2integrate/converters/solar/test/test_pysam_solar.py
+++ b/h2integrate/converters/solar/test/test_pysam_solar.py
@@ -411,7 +411,6 @@ def test_pvwatts_singleowner_notilt_different_site(basic_pysam_options, plant_co
         "resource_year": 2012,
         "resource_dir": None,
         "resource_filename": "35.2018863_-101.945027_psmv3_60_2012.csv",
-        "use_fixed_resource_location": False,
     }
 
     prob = om.Problem()

--- a/h2integrate/converters/wind/wind_plant_baseclass.py
+++ b/h2integrate/converters/wind/wind_plant_baseclass.py
@@ -1,3 +1,5 @@
+import re
+
 from h2integrate.core.model_baseclasses import PerformanceModelBaseClass
 
 
@@ -52,9 +54,9 @@ class WindPerformanceBaseClass(PerformanceModelBaseClass):
         # for the resource parameters `resource_vars`
         for param in resource_vars:
             params_heights = [
-                int(k.split("_")[-1].replace("m", "").strip())
-                for k, v in resource_data.items()
-                if param in k and "m" in k.split("_")[-1]
+                int(re.findall(r"_\d+m", txt)[0].strip("_").strip("m"))
+                for txt in list(resource_data.keys())
+                if bool(re.fullmatch(rf"{param}_\d+m", txt))
             ]
             if len(params_heights) > 0:
                 heights_per_parameter.update({param: params_heights})

--- a/h2integrate/resource/resource_base.py
+++ b/h2integrate/resource/resource_base.py
@@ -45,6 +45,12 @@ class ResourceBaseAPIConfig(BaseConfig):
             (plant_config['site']['latitude'], plant_config['site']['longitude']). Set to True
             to reduce computation time during optimizations or design sweeps if site location is
             not being swept. Defaults to True.
+        resource_data (dict | object, optional): Dictionary of user-input resource data.
+            Defaults to an empty dictionary.
+        resource_dir (str | Path, optional): Folder to save resource files to or
+            load resource files from. Defaults to "".
+        resource_filename (str, optional): Filename to save resource data to or load
+            resource data from. Defaults to None.
 
     Attributes:
         dataset_desc (str): description of the dataset, used in file naming.

--- a/h2integrate/resource/resource_base.py
+++ b/h2integrate/resource/resource_base.py
@@ -61,6 +61,9 @@ class ResourceBaseAPIConfig(BaseConfig):
     use_fixed_resource_location: bool = field(default=True, kw_only=True)
     dataset_desc: str = field(default="default", init=False)
     resource_type: str = field(default="none", init=False)
+    resource_data: dict | object = field(default={})
+    resource_filename: Path | str = field(default="")
+    resource_dir: Path | str | None = field(default=None)
 
 
 class ResourceBaseAPIModel(om.ExplicitComponent):
@@ -188,8 +191,9 @@ class ResourceBaseAPIModel(om.ExplicitComponent):
         the length of the data matches the expected number of timesteps.
 
         Args:
-            data (dict): DataFrame-like dictionary of resource data containing
-                "Month" and "Day" columns.
+            data (dict | pd.DataFrame): DataFrame-like dictionary of timeseries resource
+                data containing "Month" and "Day" columns.
+
         Returns:
             dict: Processed resource data with leap day handled according to configuration.
 
@@ -197,6 +201,14 @@ class ResourceBaseAPIModel(om.ExplicitComponent):
             ValueError: If the length of the data does not match ``self.n_timesteps``
                 after leap day processing.
         """
+
+        convert_to_dict = False
+        if isinstance(data, dict):
+            data = pd.DataFrame(data)
+            convert_to_dict = True
+
+        case_of_time_cols = "lower" if "month" in data.columns.to_list() else "upper"
+        data = data.rename(columns={"month": "Month", "day": "Day"})
 
         # Check if data includes leap day
         data_has_leap_day = int(data[data["Month"] == 2]["Day"].max()) == 29
@@ -231,6 +243,12 @@ class ResourceBaseAPIModel(om.ExplicitComponent):
             )
             raise ValueError(msg)
 
+        if case_of_time_cols == "lower":
+            data = data.rename(columns={"Month": "month", "Day": "day"})
+
+        if convert_to_dict:
+            data_out = {k: data[k].values for k in data.columns.to_list()}
+            return data_out
         return data
 
     def create_filename(self, latitude, longitude):

--- a/h2integrate/resource/resource_base.py
+++ b/h2integrate/resource/resource_base.py
@@ -39,12 +39,6 @@ class ResourceBaseAPIConfig(BaseConfig):
         timezone (float | int): timezone to output data in. May be used to determine whether
             to download data in UTC or local timezone. This should be populated by the value
             in sim_config['timezone']
-        use_fixed_resource_location (bool): Whether to update resource data in the `compute()`
-            method. Set to False if the site location is being swept, set to True if the
-            resource data should not be updated to the location
-            (plant_config['site']['latitude'], plant_config['site']['longitude']). Set to True
-            to reduce computation time during optimizations or design sweeps if site location is
-            not being swept. Defaults to True.
         resource_data (dict | object, optional): Dictionary of user-input resource data.
             Defaults to an empty dictionary.
         resource_dir (str | Path, optional): Folder to save resource files to or
@@ -64,7 +58,6 @@ class ResourceBaseAPIConfig(BaseConfig):
 
     timezone: int | float = field()
 
-    use_fixed_resource_location: bool = field(default=True, kw_only=True)
     dataset_desc: str = field(default="default", init=False)
     resource_type: str = field(default="none", init=False)
     resource_data: dict | object = field(default={})
@@ -435,10 +428,9 @@ class ResourceBaseAPIModel(om.ExplicitComponent):
             raise ValueError("Did not successfully download resource data.")
 
     def compute(self, inputs, outputs, discrete_inputs, discrete_outputs):
-        if not self.config.use_fixed_resource_location:
-            # update the resource data based on the input latitude and longitude
-            data = self.get_data(inputs["latitude"][0], inputs["longitude"][0], first_call=False)
-            # update the stored resource data and site
-            self.resource_site = [inputs["latitude"][0], inputs["longitude"][0]]
-            self.resource_data = data
-            discrete_outputs[f"{self.config.resource_type}_resource_data"] = data
+        # update the resource data based on the input latitude and longitude
+        data = self.get_data(inputs["latitude"][0], inputs["longitude"][0], first_call=False)
+        # update the stored resource data and site
+        self.resource_site = [inputs["latitude"][0], inputs["longitude"][0]]
+        self.resource_data = data
+        discrete_outputs[f"{self.config.resource_type}_resource_data"] = data

--- a/h2integrate/resource/solar/nlr_developer_api_base.py
+++ b/h2integrate/resource/solar/nlr_developer_api_base.py
@@ -139,7 +139,7 @@ class NLRDeveloperAPISolarResourceBase(SolarResourceBase, ResourceBaseAPIModel):
         data, data_units = self.compare_units_and_correct(data, data_units)
 
         data.update(site_data)
-        return data
+        return data | {"units": data_units}
 
     def format_timeseries_data(self, data):
         """Convert data to a dictionary with keys that follow the standardized naming convention and

--- a/h2integrate/resource/solar/nlr_developer_api_base.py
+++ b/h2integrate/resource/solar/nlr_developer_api_base.py
@@ -86,8 +86,8 @@ class NLRDeveloperAPISolarResourceBase(SolarResourceBase, ResourceBaseAPIModel):
     def load_data(self, fpath):
         """Load data from a file and format as a dictionary that:
 
-        1) follows naming convention described in SolarResourceBaseAPIModel.
-        2) is converted to standardized units described in SolarResourceBaseAPIModel.
+        1) follows naming convention described in SolarResourceBase.
+        2) is converted to standardized units described in SolarResourceBase.
 
         This method does the following steps:
 

--- a/h2integrate/resource/solar/nlr_developer_api_base.py
+++ b/h2integrate/resource/solar/nlr_developer_api_base.py
@@ -2,14 +2,15 @@ import urllib.parse
 
 import pandas as pd
 
-from h2integrate.resource.solar.solar_resource_base import SolarResourceBaseAPIModel
+from h2integrate.resource.resource_base import ResourceBaseAPIModel
+from h2integrate.resource.solar.solar_resource_base import SolarResourceBase
 from h2integrate.resource.utilities.nlr_developer_api_keys import (
     get_nlr_developer_api_key,
     get_nlr_developer_api_email,
 )
 
 
-class NLRDeveloperAPISolarResourceBase(SolarResourceBaseAPIModel):
+class NLRDeveloperAPISolarResourceBase(SolarResourceBase, ResourceBaseAPIModel):
     def setup(self):
         super().setup()
 
@@ -167,10 +168,12 @@ class NLRDeveloperAPISolarResourceBase(SolarResourceBaseAPIModel):
             )
 
             if units == "c":
-                units = units.upper()
+                units = "degC"
             if units == "w/m2":
                 units = "W/m**2"
-            if units == "nan" or units == "%":
+            if units == "nan":
+                units = "unitless"
+            if units == "%":
                 units = "percent"
             if units == "Degree" or units == "Degrees":
                 units = "deg"

--- a/h2integrate/resource/solar/nlr_developer_goes_api_models.py
+++ b/h2integrate/resource/solar/nlr_developer_goes_api_models.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from attrs import field, define, validators
 
 from h2integrate.resource.resource_base import ResourceBaseAPIConfig
@@ -36,9 +34,9 @@ class GOESAggregatedAPIConfig(ResourceBaseAPIConfig):
     dataset_desc: str = "goes_aggregated_v4"
     resource_type: str = "solar"
     valid_intervals: list[int] = field(factory=lambda: [30, 60])
-    resource_data: dict | object = field(default={})
-    resource_filename: Path | str = field(default="")
-    resource_dir: Path | str | None = field(default=None)
+    # resource_data: dict | object = field(default={})
+    # resource_filename: Path | str = field(default="")
+    # resource_dir: Path | str | None = field(default=None)
 
 
 class GOESAggregatedSolarAPI(NLRDeveloperAPISolarResourceBase):
@@ -85,9 +83,9 @@ class GOESConusAPIConfig(ResourceBaseAPIConfig):
     dataset_desc: str = "goes_conus_v4"
     resource_type: str = "solar"
     valid_intervals: list[int] = field(factory=lambda: [5, 15, 30, 60])
-    resource_data: dict | object = field(default={})
-    resource_filename: Path | str = field(default="")
-    resource_dir: Path | str | None = field(default=None)
+    # resource_data: dict | object = field(default={})
+    # resource_filename: Path | str = field(default="")
+    # resource_dir: Path | str | None = field(default=None)
 
 
 class GOESConusSolarAPI(NLRDeveloperAPISolarResourceBase):
@@ -135,9 +133,9 @@ class GOESFullDiscAPIConfig(ResourceBaseAPIConfig):
     dataset_desc: str = "goes_fulldisc_v4"
     resource_type: str = "solar"
     valid_intervals: list[int] = field(factory=lambda: [10, 30, 60])
-    resource_data: dict | object = field(default={})
-    resource_filename: Path | str = field(default="")
-    resource_dir: Path | str | None = field(default=None)
+    # resource_data: dict | object = field(default={})
+    # resource_filename: Path | str = field(default="")
+    # resource_dir: Path | str | None = field(default=None)
 
 
 class GOESFullDiscSolarAPI(NLRDeveloperAPISolarResourceBase):
@@ -201,9 +199,9 @@ class GOESTMYAPIConfig(ResourceBaseAPIConfig):
     dataset_desc: str = "goes_tmy_v4"
     resource_type: str = "solar"
     valid_intervals: list[int] = field(factory=lambda: [60])
-    resource_data: dict | object = field(default={})
-    resource_filename: Path | str = field(default="")
-    resource_dir: Path | str | None = field(default=None)
+    # resource_data: dict | object = field(default={})
+    # resource_filename: Path | str = field(default="")
+    # resource_dir: Path | str | None = field(default=None)
 
     def __attrs_post_init__(self):
         if "tmy" in self.resource_year:

--- a/h2integrate/resource/solar/nlr_developer_goes_api_models.py
+++ b/h2integrate/resource/solar/nlr_developer_goes_api_models.py
@@ -13,12 +13,6 @@ class GOESAggregatedAPIConfig(ResourceBaseAPIConfig):
     Args:
         resource_year (int): Year to use for resource data.
             Must been between 1998 and 2024 (inclusive).
-        resource_data (dict | object, optional): Dictionary of user-input resource data.
-            Defaults to an empty dictionary.
-        resource_dir (str | Path, optional): Folder to save resource files to or
-            load resource files from. Defaults to "".
-        resource_filename (str, optional): Filename to save resource data to or load
-            resource data from. Defaults to None.
 
     Attributes:
         dataset_desc (str): description of the dataset, used in file naming.
@@ -34,9 +28,6 @@ class GOESAggregatedAPIConfig(ResourceBaseAPIConfig):
     dataset_desc: str = "goes_aggregated_v4"
     resource_type: str = "solar"
     valid_intervals: list[int] = field(factory=lambda: [30, 60])
-    # resource_data: dict | object = field(default={})
-    # resource_filename: Path | str = field(default="")
-    # resource_dir: Path | str | None = field(default=None)
 
 
 class GOESAggregatedSolarAPI(NLRDeveloperAPISolarResourceBase):
@@ -62,12 +53,6 @@ class GOESConusAPIConfig(ResourceBaseAPIConfig):
     Args:
         resource_year (int): Year to use for resource data.
             Must been between 2018 and 2024 (inclusive).
-        resource_data (dict | object, optional): Dictionary of user-input resource data.
-            Defaults to an empty dictionary.
-        resource_dir (str | Path, optional): Folder to save resource files to or
-            load resource files from. Defaults to "".
-        resource_filename (str, optional): Filename to save resource data to or load
-            resource data from. Defaults to None.
 
     Attributes:
         dataset_desc (str): description of the dataset, used in file naming.
@@ -83,9 +68,6 @@ class GOESConusAPIConfig(ResourceBaseAPIConfig):
     dataset_desc: str = "goes_conus_v4"
     resource_type: str = "solar"
     valid_intervals: list[int] = field(factory=lambda: [5, 15, 30, 60])
-    # resource_data: dict | object = field(default={})
-    # resource_filename: Path | str = field(default="")
-    # resource_dir: Path | str | None = field(default=None)
 
 
 class GOESConusSolarAPI(NLRDeveloperAPISolarResourceBase):
@@ -112,12 +94,6 @@ class GOESFullDiscAPIConfig(ResourceBaseAPIConfig):
     Args:
         resource_year (int): Year to use for resource data.
             Must been between 2018 and 2024 (inclusive).
-        resource_data (dict | object, optional): Dictionary of user-input resource data.
-            Defaults to an empty dictionary.
-        resource_dir (str | Path, optional): Folder to save resource files to or
-            load resource files from. Defaults to "".
-        resource_filename (str, optional): Filename to save resource data to or load
-            resource data from. Defaults to None.
 
     Attributes:
         dataset_desc (str): description of the dataset, used in file naming.
@@ -133,9 +109,6 @@ class GOESFullDiscAPIConfig(ResourceBaseAPIConfig):
     dataset_desc: str = "goes_fulldisc_v4"
     resource_type: str = "solar"
     valid_intervals: list[int] = field(factory=lambda: [10, 30, 60])
-    # resource_data: dict | object = field(default={})
-    # resource_filename: Path | str = field(default="")
-    # resource_dir: Path | str | None = field(default=None)
 
 
 class GOESFullDiscSolarAPI(NLRDeveloperAPISolarResourceBase):
@@ -163,12 +136,6 @@ class GOESTMYAPIConfig(ResourceBaseAPIConfig):
         resource_year (str): Year to use for resource data. Can be any of the following:
             tmy-2022, tdy-2022, tgy-2022, tmy-2023, tdy-2023, tgy-2023, tmy-2024, tdy-2024,
             or tgy-2024.
-        resource_data (dict | object, optional): Dictionary of user-input resource data.
-            Defaults to an empty dictionary.
-        resource_dir (str | Path, optional): Folder to save resource files to or
-            load resource files from. Defaults to "".
-        resource_filename (str, optional): Filename to save resource data to or load
-            resource data from. Defaults to None.
 
     Attributes:
         dataset_desc (str): description of the dataset, used in file naming.
@@ -199,9 +166,6 @@ class GOESTMYAPIConfig(ResourceBaseAPIConfig):
     dataset_desc: str = "goes_tmy_v4"
     resource_type: str = "solar"
     valid_intervals: list[int] = field(factory=lambda: [60])
-    # resource_data: dict | object = field(default={})
-    # resource_filename: Path | str = field(default="")
-    # resource_dir: Path | str | None = field(default=None)
 
     def __attrs_post_init__(self):
         if "tmy" in self.resource_year:

--- a/h2integrate/resource/solar/openmeteo_solar.py
+++ b/h2integrate/resource/solar/openmeteo_solar.py
@@ -243,8 +243,8 @@ class OpenMeteoHistoricalSolarResource(SolarResourceBase, ResourceBaseAPIModel):
     def load_data(self, fpath):
         """Load data from a file and format as a dictionary that:
 
-        1) follows naming convention described in SolarResourceBaseAPIModel.
-        2) is converted to standardized units described in SolarResourceBaseAPIModel.
+        1) follows naming convention described in SolarResourceBase.
+        2) is converted to standardized units described in SolarResourceBase.
 
         This method does the following steps:
 

--- a/h2integrate/resource/solar/openmeteo_solar.py
+++ b/h2integrate/resource/solar/openmeteo_solar.py
@@ -23,12 +23,6 @@ class OpenMeteoHistoricalSolarAPIConfig(ResourceBaseAPIConfig):
             Must been between 1940 the year before the current calendar year. (inclusive).
         include_leap_day (bool, optional): If False, remove data from leap day if the
             resource_year is a leap year. Otherwise, leave leap day data in. Defaults to False.
-        resource_data (dict | object, optional): Dictionary of user-input resource data.
-            Defaults to an empty dictionary.
-        resource_dir (str | Path, optional): Folder to save resource files to or
-            load resource files from. Defaults to "".
-        resource_filename (str, optional): Filename to save resource data to or load
-            resource data from. Defaults to None.
         verify_download (bool, optional): Whether to verify the API download from the url.
             If an `openmeteo_requests.Client.OpenMeteoRequestsError` error is thrown,
             try setting to True. Defaults to False.
@@ -50,9 +44,6 @@ class OpenMeteoHistoricalSolarAPIConfig(ResourceBaseAPIConfig):
     dataset_desc: str = "openmeteo_archive_solar"
     resource_type: str = "solar"
     valid_intervals: list[int] = field(factory=lambda: [60])
-    # resource_data: dict | object = field(default={})
-    # resource_filename: Path | str = field(default="")
-    # resource_dir: Path | str | None = field(default=None)
     verify_download: bool = field(default=False)
 
 

--- a/h2integrate/resource/solar/openmeteo_solar.py
+++ b/h2integrate/resource/solar/openmeteo_solar.py
@@ -50,9 +50,9 @@ class OpenMeteoHistoricalSolarAPIConfig(ResourceBaseAPIConfig):
     dataset_desc: str = "openmeteo_archive_solar"
     resource_type: str = "solar"
     valid_intervals: list[int] = field(factory=lambda: [60])
-    resource_data: dict | object = field(default={})
-    resource_filename: Path | str = field(default="")
-    resource_dir: Path | str | None = field(default=None)
+    # resource_data: dict | object = field(default={})
+    # resource_filename: Path | str = field(default="")
+    # resource_dir: Path | str | None = field(default=None)
     verify_download: bool = field(default=False)
 
 

--- a/h2integrate/resource/solar/openmeteo_solar.py
+++ b/h2integrate/resource/solar/openmeteo_solar.py
@@ -309,7 +309,7 @@ class OpenMeteoHistoricalSolarResource(SolarResourceBase, ResourceBaseAPIModel):
         # update solar resource data with site data
         data.update(site_data)
 
-        return data
+        return data | {"units": data_units}
 
     def format_timeseries_data(self, data):
         """Convert data to a dictionary with keys that follow the standardized naming convention and

--- a/h2integrate/resource/solar/openmeteo_solar.py
+++ b/h2integrate/resource/solar/openmeteo_solar.py
@@ -8,9 +8,9 @@ import openmeteo_requests
 from attrs import field, define, validators
 from retry_requests import retry
 
-from h2integrate.resource.resource_base import ResourceBaseAPIConfig
+from h2integrate.resource.resource_base import ResourceBaseAPIModel, ResourceBaseAPIConfig
 from h2integrate.resource.utilities.download_tools import make_time_index_openmeteo
-from h2integrate.resource.solar.solar_resource_base import SolarResourceBaseAPIModel
+from h2integrate.resource.solar.solar_resource_base import SolarResourceBase
 
 
 @define(kw_only=True)
@@ -56,7 +56,7 @@ class OpenMeteoHistoricalSolarAPIConfig(ResourceBaseAPIConfig):
     verify_download: bool = field(default=False)
 
 
-class OpenMeteoHistoricalSolarResource(SolarResourceBaseAPIModel):
+class OpenMeteoHistoricalSolarResource(SolarResourceBase, ResourceBaseAPIModel):
     def setup(self):
         # create the input dictionary for OpenMeteoHistoricalSolarAPIConfig
         resource_specs = self.helper_setup_method()
@@ -355,8 +355,13 @@ class OpenMeteoHistoricalSolarResource(SolarResourceBaseAPIModel):
         for c in data_cols_init:
             units = c.split("(")[-1].strip(")").replace("°", "deg").replace("%", "unitless")
             units = (
-                units.replace("undefined", "unitless").replace("m²", "m**2").replace("degC", "C")
+                units.replace("undefined", "unitless").replace(
+                    "m²", "m**2"
+                )  # .replace("degC", "C")
             )
+
+            if units == "C":
+                units = "degC"
 
             new_c = c.split("(")[0].replace("air", "").replace("at ", "")
             new_c = new_c.replace(f"({units})", "").strip().replace(" ", "_").replace("__", "_")

--- a/h2integrate/resource/solar/solar_resource_base.py
+++ b/h2integrate/resource/solar/solar_resource_base.py
@@ -1,30 +1,27 @@
+from typing import ClassVar
+
 from openmdao.utils import units
 
-from h2integrate.resource.resource_base import ResourceBaseAPIModel
 
-
-class SolarResourceBaseAPIModel(ResourceBaseAPIModel):
-    def setup(self):
-        super().setup()
-
-        self.output_vars_to_units = {
-            "wind_direction": "deg",
-            "wind_speed": "m/s",
-            "temperature": "C",
-            "pressure": "mbar",
-            "relative_humidity": "percent",
-            "ghi": "W/m**2",
-            "dni": "W/m**2",
-            "dhi": "W/m**2",
-            "clearsky_ghi": "W/m**2",
-            "clearsky_dni": "W/m**2",
-            "clearsky_dhi": "W/m**2",
-            "dew_point": "C",
-            "surface_albedo": "percent",
-            "solar_zenith_angle": "deg",
-            "snow_depth": "cm",
-            "precipitable_water": "cm",
-        }
+class SolarResourceBase:
+    output_vars_to_units: ClassVar[dict[str, str]] = {
+        "wind_direction": "deg",
+        "wind_speed": "m/s",
+        "temperature": "degC",
+        "pressure": "mbar",
+        "relative_humidity": "percent",
+        "ghi": "W/m**2",
+        "dni": "W/m**2",
+        "dhi": "W/m**2",
+        "clearsky_ghi": "W/m**2",
+        "clearsky_dni": "W/m**2",
+        "clearsky_dhi": "W/m**2",
+        "dew_point": "degC",
+        "surface_albedo": "unitless",
+        "solar_zenith_angle": "deg",
+        "snow_depth": "cm",
+        "precipitable_water": "cm",
+    }
 
     def compare_units_and_correct(self, data, data_units):
         """Convert data to standard units defined in ``output_vars_to_units``.

--- a/h2integrate/resource/solar/test/test_resource_models.py
+++ b/h2integrate/resource/solar/test/test_resource_models.py
@@ -185,7 +185,7 @@ def test_solar_resource_h2i_download(
     with subtests.test("Site Elevation"):
         assert pytest.approx(solar_data["elevation"], rel=1e-6) == 449
 
-    data_keys = [k for k, v in solar_data.items() if not isinstance(v, float | int | str)]
+    data_keys = [k for k, v in solar_data.items() if not isinstance(v, float | int | str | dict)]
     for k in data_keys:
         with subtests.test(f"{k} resource data is 8760"):
             assert len(solar_data[k]) == 8760
@@ -243,7 +243,7 @@ def test_solar_resource_h2i_download_leap_year(
     with subtests.test("Site Elevation"):
         assert pytest.approx(solar_data["elevation"], rel=1e-6) == 71
 
-    data_keys = [k for k, v in solar_data.items() if not isinstance(v, float | int | str)]
+    data_keys = [k for k, v in solar_data.items() if not isinstance(v, float | int | str | dict)]
     for k in data_keys:
         with subtests.test(f"{k} resource data is 8760"):
             assert len(solar_data[k]) == 8760

--- a/h2integrate/resource/wind/nlr_developer_wtk_api_base.py
+++ b/h2integrate/resource/wind/nlr_developer_wtk_api_base.py
@@ -161,7 +161,7 @@ class NLRDeveloperAPIWindResourceBase(WindResourceBase, ResourceBaseAPIModel):
         # include site data with data
         data.update(site_data)
 
-        return data
+        return data | {"units": data_units}
 
     def format_timeseries_data(self, data):
         """Convert data to a dictionary with keys that follow the standardized naming convention and

--- a/h2integrate/resource/wind/nlr_developer_wtk_api_base.py
+++ b/h2integrate/resource/wind/nlr_developer_wtk_api_base.py
@@ -112,8 +112,8 @@ class NLRDeveloperAPIWindResourceBase(WindResourceBase, ResourceBaseAPIModel):
     def load_data(self, fpath):
         """Load data from a file and format as a dictionary that:
 
-        1) follows naming convention described in WindResourceBaseAPIModel.
-        2) is converted to standardized units described in WindResourceBaseAPIModel.
+        1) follows naming convention described in WindResourceBase.
+        2) is converted to standardized units described in WindResourceBase.
 
         This method does the following steps:
 

--- a/h2integrate/resource/wind/nlr_developer_wtk_api_base.py
+++ b/h2integrate/resource/wind/nlr_developer_wtk_api_base.py
@@ -20,12 +20,6 @@ class WTKNLRDeveloperAPIConfig(ResourceBaseAPIConfig):
     Args:
         resource_year (int): Year to use for resource data.
             Must been between 2007 and 2014 (inclusive).
-        resource_data (dict | object, optional): Dictionary of user-input resource data.
-            Defaults to an empty dictionary.
-        resource_dir (str | Path, optional): Folder to save resource files to or
-            load resource files from. Defaults to "".
-        resource_filename (str, optional): Filename to save resource data to or load
-            resource data from. Defaults to None.
 
     Attributes:
         dataset_desc (str): description of the dataset, used in file naming.
@@ -41,9 +35,6 @@ class WTKNLRDeveloperAPIConfig(ResourceBaseAPIConfig):
     dataset_desc: str = "wtk_v2"
     resource_type: str = "wind"
     valid_intervals: list[int] = field(factory=lambda: [5, 15, 30, 60])
-    # resource_data: dict | object = field(default={})
-    # resource_filename: Path | str = field(default="")
-    # resource_dir: Path | str | None = field(default=None)
 
 
 class NLRDeveloperAPIWindResourceBase(WindResourceBase, ResourceBaseAPIModel):

--- a/h2integrate/resource/wind/nlr_developer_wtk_api_base.py
+++ b/h2integrate/resource/wind/nlr_developer_wtk_api_base.py
@@ -1,6 +1,5 @@
 import warnings
 import urllib.parse
-from pathlib import Path
 
 import pandas as pd
 from attrs import field, define, validators
@@ -42,9 +41,9 @@ class WTKNLRDeveloperAPIConfig(ResourceBaseAPIConfig):
     dataset_desc: str = "wtk_v2"
     resource_type: str = "wind"
     valid_intervals: list[int] = field(factory=lambda: [5, 15, 30, 60])
-    resource_data: dict | object = field(default={})
-    resource_filename: Path | str = field(default="")
-    resource_dir: Path | str | None = field(default=None)
+    # resource_data: dict | object = field(default={})
+    # resource_filename: Path | str = field(default="")
+    # resource_dir: Path | str | None = field(default=None)
 
 
 class NLRDeveloperAPIWindResourceBase(WindResourceBase, ResourceBaseAPIModel):

--- a/h2integrate/resource/wind/nlr_developer_wtk_api_base.py
+++ b/h2integrate/resource/wind/nlr_developer_wtk_api_base.py
@@ -5,8 +5,8 @@ from pathlib import Path
 import pandas as pd
 from attrs import field, define, validators
 
-from h2integrate.resource.resource_base import ResourceBaseAPIConfig
-from h2integrate.resource.wind.wind_resource_base import WindResourceBaseAPIModel
+from h2integrate.resource.resource_base import ResourceBaseAPIModel, ResourceBaseAPIConfig
+from h2integrate.resource.wind.wind_resource_base import WindResourceBase
 from h2integrate.resource.utilities.nlr_developer_api_keys import (
     get_nlr_developer_api_key,
     get_nlr_developer_api_email,
@@ -47,7 +47,7 @@ class WTKNLRDeveloperAPIConfig(ResourceBaseAPIConfig):
     resource_dir: Path | str | None = field(default=None)
 
 
-class NLRDeveloperAPIWindResourceBase(WindResourceBaseAPIModel):
+class NLRDeveloperAPIWindResourceBase(WindResourceBase, ResourceBaseAPIModel):
     def setup(self):
         super().setup()
 

--- a/h2integrate/resource/wind/openmeteo_wind.py
+++ b/h2integrate/resource/wind/openmeteo_wind.py
@@ -306,7 +306,7 @@ class OpenMeteoHistoricalWindResource(WindResourceBase, ResourceBaseAPIModel):
         # update wind resource data with site data
         data.update(site_data)
 
-        return data
+        return data | {"units": data_units}
 
     def format_timeseries_data(self, data):
         """Convert data to a dictionary with keys that follow the standardized naming convention and

--- a/h2integrate/resource/wind/openmeteo_wind.py
+++ b/h2integrate/resource/wind/openmeteo_wind.py
@@ -45,9 +45,9 @@ class OpenMeteoHistoricalWindAPIConfig(ResourceBaseAPIConfig):
     dataset_desc: str = "openmeteo_archive"
     resource_type: str = "wind"
     valid_intervals: list[int] = field(factory=lambda: [60])
-    resource_data: dict | object = field(default={})
-    resource_filename: Path | str = field(default="")
-    resource_dir: Path | str | None = field(default=None)
+    # resource_data: dict | object = field(default={})
+    # resource_filename: Path | str = field(default="")
+    # resource_dir: Path | str | None = field(default=None)
     verify_download: bool = field(default=False)
 
 

--- a/h2integrate/resource/wind/openmeteo_wind.py
+++ b/h2integrate/resource/wind/openmeteo_wind.py
@@ -7,8 +7,8 @@ import openmeteo_requests
 from attrs import field, define, validators
 from retry_requests import retry
 
-from h2integrate.resource.resource_base import ResourceBaseAPIConfig
-from h2integrate.resource.wind.wind_resource_base import WindResourceBaseAPIModel
+from h2integrate.resource.resource_base import ResourceBaseAPIModel, ResourceBaseAPIConfig
+from h2integrate.resource.wind.wind_resource_base import WindResourceBase
 from h2integrate.resource.utilities.download_tools import make_time_index_openmeteo
 
 
@@ -51,7 +51,7 @@ class OpenMeteoHistoricalWindAPIConfig(ResourceBaseAPIConfig):
     verify_download: bool = field(default=False)
 
 
-class OpenMeteoHistoricalWindResource(WindResourceBaseAPIModel):
+class OpenMeteoHistoricalWindResource(WindResourceBase, ResourceBaseAPIModel):
     def setup(self):
         # create the input dictionary for OpenMeteoHistoricalWindAPIConfig
         resource_specs = self.helper_setup_method()

--- a/h2integrate/resource/wind/openmeteo_wind.py
+++ b/h2integrate/resource/wind/openmeteo_wind.py
@@ -239,8 +239,8 @@ class OpenMeteoHistoricalWindResource(WindResourceBase, ResourceBaseAPIModel):
     def load_data(self, fpath):
         """Load data from a file and format as a dictionary that:
 
-        1) follows naming convention described in WindResourceBaseAPIModel.
-        2) is converted to standardized units described in WindResourceBaseAPIModel.
+        1) follows naming convention described in WindResourceBase.
+        2) is converted to standardized units described in WindResourceBase.
 
         This method does the following steps:
 

--- a/h2integrate/resource/wind/openmeteo_wind.py
+++ b/h2integrate/resource/wind/openmeteo_wind.py
@@ -45,9 +45,6 @@ class OpenMeteoHistoricalWindAPIConfig(ResourceBaseAPIConfig):
     dataset_desc: str = "openmeteo_archive"
     resource_type: str = "wind"
     valid_intervals: list[int] = field(factory=lambda: [60])
-    # resource_data: dict | object = field(default={})
-    # resource_filename: Path | str = field(default="")
-    # resource_dir: Path | str | None = field(default=None)
     verify_download: bool = field(default=False)
 
 

--- a/h2integrate/resource/wind/test/test_openmeteo_wind_api.py
+++ b/h2integrate/resource/wind/test/test_openmeteo_wind_api.py
@@ -57,7 +57,7 @@ def test_wind_resource_web_download(
     with subtests.test("Site Elevation"):
         assert pytest.approx(wind_data["elevation"], rel=1e-6) == elevation
 
-    data_keys = [k for k, v in wind_data.items() if not isinstance(v, float | int | str)]
+    data_keys = [k for k, v in wind_data.items() if not isinstance(v, float | int | str | dict)]
     for k in data_keys:
         with subtests.test(f"{k} resource data is 8760"):
             assert len(wind_data[k]) == 8760
@@ -116,7 +116,7 @@ def test_wind_resource_h2i_download(
     with subtests.test("Site Elevation"):
         assert pytest.approx(wind_data["elevation"], rel=1e-6) == elevation
 
-    data_keys = [k for k, v in wind_data.items() if not isinstance(v, float | int | str)]
+    data_keys = [k for k, v in wind_data.items() if not isinstance(v, float | int | str | dict)]
     for k in data_keys:
         with subtests.test(f"{k} resource data is 8760"):
             assert len(wind_data[k]) == 8760
@@ -176,7 +176,7 @@ def test_wind_resource_h2i_download_leap_year(
     with subtests.test("Site Elevation"):
         assert pytest.approx(wind_data["elevation"], rel=1e-6) == elevation
 
-    data_keys = [k for k, v in wind_data.items() if not isinstance(v, float | int | str)]
+    data_keys = [k for k, v in wind_data.items() if not isinstance(v, float | int | str | dict)]
     for k in data_keys:
         with subtests.test(f"{k} resource data is 8760"):
             assert len(wind_data[k]) == 8760

--- a/h2integrate/resource/wind/wind_resource_base.py
+++ b/h2integrate/resource/wind/wind_resource_base.py
@@ -1,22 +1,20 @@
+import warnings
+from typing import ClassVar
+
 from openmdao.utils import units
 
-from h2integrate.resource.resource_base import ResourceBaseAPIModel
 
-
-class WindResourceBaseAPIModel(ResourceBaseAPIModel):
-    def setup(self):
-        super().setup()
-
-        self.output_vars_to_units = {
-            "wind_direction": "deg",
-            "wind_speed": "m/s",
-            "temperature": "degC",
-            "pressure": "atm",
-            "precipitation_rate": "mm/h",
-            "relative_humidity": "percent",
-            "is_day": "unitless",
-            "specifichumidity": "percent",
-        }
+class WindResourceBase:
+    output_vars_to_units: ClassVar[dict[str, str]] = {
+        "wind_direction": "deg",
+        "wind_speed": "m/s",
+        "temperature": "degC",
+        "pressure": "atm",
+        "precipitation_rate": "mm/h",
+        "relative_humidity": "percent",
+        "is_day": "unitless",
+        "specifichumidity": "percent",
+    }
 
     def compare_units_and_correct(self, data, data_units):
         """Convert data to standard units defined in ``output_vars_to_units``.
@@ -57,7 +55,13 @@ class WindResourceBaseAPIModel(ResourceBaseAPIModel):
                     data_units[data_col] = desired_units
             else:
                 if len(output_var) < 1:
-                    raise Warning(f"{data_col} not found as common variable.")
+                    warnings.warn(
+                        f"{data_col} not found as common variable.", UserWarning, stacklevel=3
+                    )
                 else:
-                    raise Warning(f"{data_col} not found as a unique common variable.")
+                    warnings.warn(
+                        f"{data_col} not found as a unique common variable.",
+                        UserWarning,
+                        stacklevel=3,
+                    )
         return data, data_units


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELETE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code highlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Re-organization of Resource Model Inheritance
<!-- Describe your feature here. Please include any code snippets or examples in this section. -->
This PR was inspired by PR #854. With #854, a new resource baseclass is used but the existing organization/inheritance structure of resource models resulted in a lot of duplicate code. 

The resource-specific base-classes (`SolarResourceBaseAPIModel` and `WindResourceBaseAPIModel`)  have been renamed (no longer include `APIModel` in the name) and refactored to **not** inherit the `ResourceBaseAPIModel`.

The models that previously inherited `SolarResourceBaseAPIModel` and `WindResourceBaseAPIModel` now inherit both their resource-specific model and the `ResourceBaseAPIModel`.

Other changes/clean-ups/fixes are:
- `ResourceBaseAPIConfig`: added `resource_dir`, `resource_filename`, and `resource_data` as attributes and removed those attributes from the configurations that inherit it (reduces duplicate code)
- Fixed temperature units in the solar resource models
- Changed `raise Warning` to `warnings.warn` in the wind resource baseclass
- Updated logic in the wind plant baseclass to get resource heights for different resource parameters (more robust to extra resource data)
- Updated the leap year method to be able to handle dictionaries

Reviewers - let me know your thoughts on the optional changes and whether you are for them or against them!

Other changes (will push up soon):
- [x] Output the units for the resource data
- [ ] (optional): move some methods (`add_resource_start_end_times` and `process_leap_day`) from the resource baseclass to a new file in `resource/utilites/time_tools.py`
- [x] (optional): remove usage of `use_fixed_resource_location` (no longer needed after site components have been integrated)


## Section 1: Type of Contribution
<!-- Check all that apply to help reviewers understand your contribution -->
- [ ] Feature Enhancement
  - [ ] Framework
  - [ ] New Model
  - [x] Updated Model
  - [ ] Tools/Utilities
  - [ ] Other (please describe):
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] CI Changes
- [ ] Other (please describe):

## Section 2: Draft PR Checklist
<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
<!--Complete when opening a draft PR. -->
- [x] Open draft PR
- [x] Describe the feature that will be added
- [x] Fill out TODO list steps
- [-] Describe requested feedback from reviewers on draft PR
- [x] Complete Section 8: New Model Checklist (if applicable)
<!-- Describe the feature in this PR and outline next steps -->
### TODO:
- [ ] Update changelog

### Type of Reviewer Feedback Requested (on Draft PR)
<!-- Outline the feedback that would be helpful from reviewers while it's a draft PR -->
**Structural feedback**:

**Implementation feedback**:

**Other feedback**:

## Section 3: General PR Checklist
<!--Complete when converting draft PR to a merge-ready PR. -->
- [x] PR description thoroughly describes the new feature, bug fix, etc.
- [-] Added tests for new functionality or bug fixes
- [x] Tests pass (If not, and this is expected, please elaborate in the Section 6: Test Results)
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [x] Examples have been updated (if applicable)
- [ ] `CHANGELOG.md`
  - [ ] At least one complete sentence has been provided to describe the changes made in this PR
  - [ ] After the above, a hyperlink has been provided to the PR using the following format:
    "A complete thought. [PR XYZ]((https://github.com/NatLabRockies/H2Integrate/pull/XYZ)", where
    `XYZ` should be replaced with the actual number.

## Section 4: Related Issues
<!--If this PR relates to an existing GitHub issue, please link the issue and indicate whether this PR would fully or partially resolve that issue. Please also link any issues that were created due to this PR-->


## Section 5: Impacted Areas of the Software
<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why. Can exclude CHANGELOG.md, doc pages and supported_models.py.
-->
### Section 5.1: New Files
N/A

### Section 5.2: Modified Files
- `h2integrate/resources/`
  - `method1`: What and why something was changed in one sentence or less.

## Section 6: Additional Supporting Information
<!--Add any other context about the problem here.-->


## Section 7: Test Results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->

## Section 8 (Optional): New Model Checklist
<!-- Complete this section only if you checked "New Model" above -->
- [ ] **Model Structure**:
  - [ ] Follows established naming conventions outlined in `docs/developer_guide/coding_guidelines.md`
  - [ ] Used `attrs` class to define the `Config` to load in attributes for the model
    - [ ] If applicable: inherit from `BaseConfig` or `CostModelBaseConfig`
  - [ ] Added: `initialize()` method, `setup()` method, `compute()` method
    - [ ] If applicable: inherit from `CostModelBaseClass`
- [ ] **Integration**: Model has been properly integrated into H2Integrate
  - [ ] Add the new model to the appropriate `__init__.py` file to ensure it is properly imported and used in `supported_models.py`
  - [ ] Added to `supported_models.py`
  - [ ] If a new commodity_type is added, update `create_financial_model` in `h2integrate_model.py`
- [ ] **Tests**: Unit tests have been added for the new model
  - [ ] [Pytest-style unit tests](https://realpython.com/pytest-python-testing/)
  - [ ] Unit tests are in a "test" folder within the folder a new model was added to
  - [ ] If applicable add integration tests
- [ ] **Example**: If applicable, a working example demonstrating the new model has been created
  - [ ] Input file comments
  - [ ] Run file comments
  - [ ] Example has been tested and runs successfully in `test_all_examples.py`
- [ ] **Documentation**:
  - [ ] Write docstrings using the [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
  - [ ] Model added to the main models list in `docs/user_guide/model_overview.md`
    - [ ] Model documentation page added to the appropriate `docs/` section
    - [ ] `<model_name>.md` is added to the `_toc.yml`
  - [ ] Run `generate_class_hierarchy.py` to update the class hierarchy diagram in `docs/developer_guide/class_structure.md`





<!--
__ For NLR use __
Release checklist:
- [ ] Update the version in h2integrate/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NatLabRockies/H2Integrate repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
