### PR TITLE
Enable `from_dict` to Handle an Object of the Correct Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@
   - `ResourceBaseH5Config` and `ResourceBaseH5Model` are base configuration classes for these resource datasets
 - Synced peak load management (PLM) with the system-level control (SLC) paradigm: `PeakLoadManagementOptimizedStorageController` can now be used as a storage tech's SLC sub-controller via a new opt-in `constrain_dispatch_to_set_point` config field, which caps dispatch at the provided demand signal without changing its existing peak-window behavior by default. [Issue 749](https://github.com/NatLabRockies/H2Integrate/issues/749)
 - Bugfix in LCO breakdown function to include sales tax and typo-fix in commodity units extraction in ProFAST finance models [PR 867](https://github.com/NatLabRockies/H2Integrate/pull/867)
-
+- Enable `BaseConfig.from_dict` to receive an instance of the object it should be creating to enable
+  `attrs` converter routines to safely handle instances of existing configuration objects or
+  configuration dictionaries for defining objects once.
 
 ## 0.9 [August 10, 2026]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Bugfix in LCO breakdown function to include sales tax and typo-fix in commodity units extraction in ProFAST finance models [PR 867](https://github.com/NatLabRockies/H2Integrate/pull/867)
 - Enable `BaseConfig.from_dict` to receive an instance of the object it should be creating to enable
   `attrs` converter routines to safely handle instances of existing configuration objects or
-  configuration dictionaries for defining objects once.
+  configuration dictionaries for defining objects once. [PR 869](https://github.com/NatLabRockies/H2Integrate/pull/869)
 
 ## 0.9 [August 10, 2026]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased [TBD]
+
 - Enable `PySAMWindPlantPerformanceModel` to accept more than 300 turbines by overriding the default maximum in the PySAM model. [PR 831](https://github.com/NatLabRockies/H2Integrate/pull/831)
 - Add `PySAMWavePerformanceModel` and `WaveResource` to wrap PySAM MhkWave as an H2I performance model, replacing the HOPP wave module in example 09. [PR 825](https://github.com/NatLabRockies/H2Integrate/pull/825)
 - Replace HOPP with native H2I wind, solar, and battery models in example 11. Adds `percent_load_missed` and `curtailment_percent` outputs to `DemandComponentBase`, allows zero capacity in wind/solar/battery performance models. [PR 826](https://github.com/NatLabRockies/H2Integrate/pull/826)
@@ -24,9 +25,12 @@
   - `ResourceBaseH5Config` and `ResourceBaseH5Model` are base configuration classes for these resource datasets
 - Synced peak load management (PLM) with the system-level control (SLC) paradigm: `PeakLoadManagementOptimizedStorageController` can now be used as a storage tech's SLC sub-controller via a new opt-in `constrain_dispatch_to_set_point` config field, which caps dispatch at the provided demand signal without changing its existing peak-window behavior by default. [Issue 749](https://github.com/NatLabRockies/H2Integrate/issues/749)
 - Bugfix in LCO breakdown function to include sales tax and typo-fix in commodity units extraction in ProFAST finance models [PR 867](https://github.com/NatLabRockies/H2Integrate/pull/867)
+
+
 ## 0.9 [August 10, 2026]
 
 ### New Features
+
 - Creates the `EIANaturalGasFeedstockConfig` and `EIANaturalGasFeedstockCostModel` to load EIA natural gas prices from file or to retrieve them from the EIA API. The model is able to retrieve the US or any of the 50 states' annual or monthly values, which will be converted into an hourly timeseries. [PR 719](https://github.com/NatLabRockies/H2Integrate/pull/719)
 - Add electric arc furnace performance and cost models based on the Carnegie Mellon University DecarbSTEEL v5 excel model [PR 686](https://github.com/NatLabRockies/H2Integrate/pull/686)
   - Adds scrap-only performance model
@@ -37,7 +41,9 @@
 - Added a thermal-nuclear (light-water reactor) model and a high-temperature steam electrolysis model. [PR 807](https://github.com/NatLabRockies/H2Integrate/pull/807)
 
 ### Updates
+
 #### Modeling
+
 - Change commodity in DRI and EAF model from pig iron to sponge iron based on likely carbon content [PR 670](https://github.com/NatLabRockies/H2Integrate/pull/670)
 - Added electricity and water consumption profiles as outputs to the `ECOElectrolyzerPerformanceModel` [PR 690](https://github.com/NatLabRockies/H2Integrate/pull/690)
 - Add per-year pricing support for Grid and Feedstock cost models, allowing price arrays of length `plant_life` in addition to scalar and per-timestep arrays. [PR 700](https://github.com/NatLabRockies/H2Integrate/pull/700)
@@ -61,8 +67,8 @@
 - Added `calc_azimuth_angle()` to `PYSAMSolarPlantPerformanceModel` to provide default azimuth angle based on whether the site is in the northern or southern hemisphere [PR 806](https://github.com/NatLabRockies/H2Integrate/pull/806)
 - Renamed `OpenLoopStorageControlBase` to `OpenLoopControlBase` and `OpenLoopStorageControlBaseConfig` to `OpenLoopControlBaseConfig` and moved them out of the control storage sub-directory. [PR 828](https://github.com/NatLabRockies/H2Integrate/pull/828)
 
-
 #### Infrastructure
+
 - Grouped closely related test assertions into behavior-focused subtests and documented when to use subtests in the developer coding guidelines. [PR 839](https://github.com/NatLabRockies/H2Integrate/pull/839)
 - Renamed `{commodity}_demand` inputs to `{commodity}_set_point` on all converter performance components to align with storage baseclass naming and distinguish converter operating targets from demand components. [PR 691](https://github.com/NatLabRockies/H2Integrate/pull/691)
 - Minor cleanup to `pose_optimization` [PR 695](https://github.com/NatLabRockies/H2Integrate/pull/695)
@@ -95,6 +101,7 @@
 - Added two new fuel cell models: `PEMH2FuelCellPerformanceModel` to model a PEM hydrogen fuel cell and `SONGFuelCellPerformanceModel` to model a natural gas solid oxide fuel cell [PR 794](https://github.com/NatLabRockies/H2Integrate/pull/794)
 
 ### Fixes
+
 - Bug fix so multi-level output path won't throw an error; updated test for EIA API handling. [PR 820](https://github.com/NatLabRockies/H2Integrate/pull/820)
 - Bugfix for round-trip efficiency handling when calling `check_inputs` around `StoragePerformanceModel` [PR 684](https://github.com/NatLabRockies/H2Integrate/pull/684)
 - Bugfix. Include nuclear in electricity producing tech list and improve error message for zero-length electricity producing techs in model when electricity is specified as the commodity. [PR 685](https://github.com/NatLabRockies/H2Integrate/pull/685)

--- a/h2integrate/core/test/test_utilities.py
+++ b/h2integrate/core/test/test_utilities.py
@@ -603,6 +603,10 @@ def test_BaseConfig(subtests):
         with pytest.raises(AttributeError, match=msg):
             demo = BaseDemoModelStrict({})
 
+    with subtests.test("Check instance is returned back"):
+        demo = DemoConfig(x=13, y=12)
+        assert demo == DemoConfig.from_dict(demo)
+
 
 @pytest.mark.unit
 def test_yaml_no_duplicate_keys(subtests):

--- a/h2integrate/core/utilities.py
+++ b/h2integrate/core/utilities.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, TypeVar
 from collections import OrderedDict
 
 import attrs
@@ -11,6 +11,9 @@ try:
     from pyxdsm.XDSM import FUNC, XDSM
 except ImportError:
     pass
+
+
+BaseConfigType = TypeVar("BaseConfigType", bound="BaseConfig")
 
 
 def create_xdsm_from_config(config, output_file="connections_xdsm"):
@@ -113,7 +116,12 @@ class BaseConfig:
     """
 
     @classmethod
-    def from_dict(cls, data: dict, strict=True, additional_cls_name: str | None = None):
+    def from_dict(
+        cls: type[BaseConfigType],
+        data: dict | type[BaseConfigType],
+        strict=True,
+        additional_cls_name: str | None = None,
+    ) -> BaseConfigType:
         """Maps a data dictionary to an ``attrs``-defined class.
 
         Args:
@@ -127,6 +135,9 @@ class BaseConfig:
         Returns:
             cls: The ``attrs``-defined class.
         """
+        if isinstance(data, cls):
+            return data
+
         # Check for any inputs that aren't part of the class definition
         if strict is True:
             class_attr_names = [a.name for a in cls.__attrs_attrs__]

--- a/h2integrate/core/utilities.py
+++ b/h2integrate/core/utilities.py
@@ -125,7 +125,8 @@ class BaseConfig:
         """Maps a data dictionary to an ``attrs``-defined class.
 
         Args:
-            data (dict): The data dictionary to be mapped.
+            data (dict | BaseConfig): The data dictionary to be mapped or an existing object of
+                the type that would otherwise be created.
             strict (bool): A flag enabling strict parameter processing, meaning that no extra
                 parameters may be passed in or an AttributeError will be raised.
             additional_cls_name (str | None): The name of the model class creating the configuration


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELETE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code highlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Allow `BaseConfig.from_dict` to Accept and Return Existing Objects
<!-- Describe your feature here. Please include any code snippets or examples in this section. -->
This PR makes a small change to the behavior of `BaseConfig.from_dict` to allow the input `data` to be either a dictionary or an object of the type that will be created. When an already created object is passed, and is of the same type as the one that will be created, then it immediately returned. This change enables `attrs` dataclasses to pass around already-instantiated objects rather than storing the dictionary and the object or deconstructing the object in order to share a common definition.

The immediate use case for this enhancement is coming from #833, but the general use case can be boiled down the simplistic example below where one central analysis object needs to pass around an already validated and enhanced configuration object. The real convenience of this use case is the ability to define the common configuration in one place within a configuration dictionary and allow other analysis routines to have access to that information efficiently.

```python
import attrs
from attrs import define, field
from h2integrate.core.utilities import BaseConfig

@define
class CommonConfig(BaseConfig):
    """A common configuration that has some additional routines or data creation that enhances
    the use or abilities of the attributes.
    """
    field1: int = field()
    field2: int = field()
    field3: int = field(init=False)
    field4: int = field(init=False)

    def __attrs_post_init__(self):
        self.some_useful_routine()

    def some_useful_routine(self):
        """Some modification/enhanced use of :py:attr:`field1` and :py:attr:`field2`."""
        self.field3 = self.field1 * self.field2
        self.field4 = self.field1 ** self.field2

@define
class AnalysisRoutine1(BaseConfig):
    """A singular analysis class with a focused purpose"""
    common: CommonConfig = field(converter=CommonConfig.from_dict)
    a: int = field()
    b: float = field()

    def __attrs_post_init__(self):
        self.run()

    def run(self):
        """Performs one component of an analysis that makes use of :py:attr:`common`."""
        ...

@define
class AnalysisRoutine2(BaseConfig):
    """Another singular analysis class with a completely separate, but focused purpose."""
    common: CommonConfig = field(converter=CommonConfig.from_dict)
    a: int = field()
    c: float = field()

    def __attrs_post_init__(self):
        self.run()

    def run(self):
        """Performs one component of an analysis that makes use of :py:attr:`common`."""
        ...

@define
class ParentConfig(BaseConfig):
    common: CommonConfig = field(converter=CommonConfig.from_dict)
    routine1_config: dict | None = field()
    routine2_config: dict | None = field()
    routine1: AnalysisRoutine1 = field(init=False)
    routine2: AnalysisRoutine2 = field(init=False)

    def __attrs_post_init__(self):
        common_config = {"common": self.common}
        self.routine1 = AnalysisRoutine1.from_dict(self.routine1_config | common_config)
        self.routine2 = AnalysisRoutine2.from_dict(self.routine2_config | common_config)

analysis_config = {
    "common": {"field1": 4, "field2": 5},
    "routine1_config": {"a": 1, "b": 2.14},
    "routine2_config": {"a": 2, "c": 3.3},
}


>>> parent = ParentConfig.from_dict(analysis_config)
>>> parent
# printed much nicer than the real output looks so it's easier to see what's happening
ParentConfig(
    common=CommonConfig(field1=4, field2=5, field3=20, field4=1024),
    routine1_config={'a': 1, 'b': 2.14},
    routine2_config={'a': 2, 'c': 3.3},
    routine1=AnalysisRoutine1(common=CommonConfig(field1=4, field2=5, field3=20, field4=1024), a=1, b=2.14),
    routine2=AnalysisRoutine2(common=CommonConfig(field1=4, field2=5, field3=20, field4=1024), a=2, c=3.3)
)
```

## Section 1: Type of Contribution
<!-- Check all that apply to help reviewers understand your contribution -->
- [x] Feature Enhancement
  - [ ] Framework
  - [ ] New Model
  - [ ] Updated Model
  - [x] Tools/Utilities
  - [ ] Other (please describe):
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] CI Changes
- [ ] Other (please describe):

## Section 2: Draft PR Checklist
<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
<!--Complete when opening a draft PR. -->

N/A

## Section 3: General PR Checklist
<!--Complete when converting draft PR to a merge-ready PR. -->
- [x] PR description thoroughly describes the new feature, bug fix, etc.
- [x] Added tests for new functionality or bug fixes
- [x] Tests pass (If not, and this is expected, please elaborate in the Section 6: Test Results)
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [x] Examples have been updated (if applicable)
- [x] `CHANGELOG.md`
  - [x] At least one complete sentence has been provided to describe the changes made in this PR
  - [x] After the above, a hyperlink has been provided to the PR using the following format:
    "A complete thought. [PR XYZ]((https://github.com/NatLabRockies/H2Integrate/pull/XYZ)", where
    `XYZ` should be replaced with the actual number.

## Section 4: Related Issues
<!--If this PR relates to an existing GitHub issue, please link the issue and indicate whether this PR would fully or partially resolve that issue. Please also link any issues that were created due to this PR-->
No issues, but it felt like a more generally useful feature than one that should rely on the completion of the rest of #833.

## Section 5: Impacted Areas of the Software
<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why. Can exclude CHANGELOG.md, doc pages and supported_models.py.
-->
### Section 5.1: New Files
N/A

### Section 5.2: Modified Files
- `h2integrate/core/utilities.py`
  - `BaseConfig.from_dict`: Allows `data` to be of the same object that will be created, and immediately returns it if it is.

## Section 6: Additional Supporting Information
<!--Add any other context about the problem here.-->
N/A

## Section 7: Test Results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->

## Section 8 (Optional): New Model Checklist
<!-- Complete this section only if you checked "New Model" above -->
N/A





<!--
__ For NLR use __
Release checklist:
- [ ] Update the version in h2integrate/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NatLabRockies/H2Integrate repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
