### PR TITLE
Update NRRI mine to allow lat/lon inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Synced peak load management (PLM) with the system-level control (SLC) paradigm: `PeakLoadManagementOptimizedStorageController` can now be used as a storage tech's SLC sub-controller via a new opt-in `constrain_dispatch_to_set_point` config field, which caps dispatch at the provided demand signal without changing its existing peak-window behavior by default. [Issue 749](https://github.com/NatLabRockies/H2Integrate/issues/749)
 - Bugfix in LCO breakdown function to include sales tax and typo-fix in commodity units extraction in ProFAST finance models [PR 867](https://github.com/NatLabRockies/H2Integrate/pull/867)
 - Expanded ability to connect site information (such as latitude and longitude) to technologies and added the transport cost model `LinearDistanceCostModel` [PR 865](https://github.com/NatLabRockies/H2Integrate/pull/865)
+- Enable the use of latitude and longitude to specify the mine location [PR 875](https://github.com/NatLabRockies/H2Integrate/pull/875)
 
 ## 0.9 [August 10, 2026]
 

--- a/examples/test/test_all_examples.py
+++ b/examples/test/test_all_examples.py
@@ -2652,7 +2652,7 @@ def test_iron_electrowinning_example(subtests, temp_copy_of_example):
         model.setup()
         model.run()
         lcoi = model.model.get_val("finance_subgroup_sponge_iron.LCOS", units="USD/kg")[0]
-        assert pytest.approx(lcoi, rel=1e-4) == 2.187185703820872
+        assert pytest.approx(lcoi, rel=1e-4) == 2.174385150880128
 
     with subtests.test("Value check on MSE"):
         model.technology_config["technologies"]["iron_plant"]["model_inputs"]["shared_parameters"][
@@ -2668,7 +2668,7 @@ def test_iron_electrowinning_example(subtests, temp_copy_of_example):
         model.setup()
         model.run()
         lcoi = model.model.get_val("finance_subgroup_sponge_iron.LCOS", units="USD/kg")[0]
-        assert pytest.approx(lcoi, rel=1e-4) == 3.3399342887615115
+        assert pytest.approx(lcoi, rel=1e-4) == 3.3036489452968594
 
     with subtests.test("Value check on MOE"):
         model.technology_config["technologies"]["iron_plant"]["model_inputs"]["shared_parameters"][
@@ -2680,7 +2680,7 @@ def test_iron_electrowinning_example(subtests, temp_copy_of_example):
         model.setup()
         model.run()
         lcoi = model.model.get_val("finance_subgroup_sponge_iron.LCOS", units="USD/kg")[0]
-        assert pytest.approx(lcoi, rel=1e-4) == 2.2802793527655987
+        assert pytest.approx(lcoi, rel=1e-4) == 2.266210286641621
 
 
 @pytest.mark.integration

--- a/h2integrate/converters/iron/nrri_iron_mine.py
+++ b/h2integrate/converters/iron/nrri_iron_mine.py
@@ -21,13 +21,42 @@ class NRRIIronMinePerformanceConfig(BaseConfig):
             "Minorca" or "Tilden"
         max_ore_production_rate_tonnes_per_hr (float): capacity of the pellet plant
             in units of metric tonnes of pellets produced per hour.
-
+        latitude (float): latitude of the mine location. If not provided, it will be set
+            based on the mine name.
+        longitude (float): longitude of the mine location. If not provided, it will be set
+            based on the mine name.
     """
 
     max_ore_production_rate_tonnes_per_hr: float = field()
     mine: str = field(
         validator=validators.in_(["Hibbing", "Northshore", "United", "Minorca", "Tilden"])
     )
+    latitude: float = field(default=None)
+    longitude: float = field(default=None)
+
+    def __attrs_post_init__(self):
+        mine_locations = {
+            "Hibbing": {"latitude": 47.53, "longitude": -92.91},
+            "Northshore": {"latitude": 47.29, "longitude": -91.25},
+            "United": {"latitude": 47.34, "longitude": -92.58},
+            "Minorca": {"latitude": 47.55, "longitude": -92.52},
+            "Tilden": {"latitude": 46.48, "longitude": -87.66},
+        }
+        if self.latitude is not None or self.longitude is not None:
+            # check if the latitude and longitude are correct for the mine location
+            if self.mine in mine_locations:
+                correct_latitude = mine_locations[self.mine]["latitude"]
+                correct_longitude = mine_locations[self.mine]["longitude"]
+                if self.latitude != correct_latitude or self.longitude != correct_longitude:
+                    raise ValueError(
+                        f"Incorrect latitude and/or longitude for mine {self.mine}. "
+                        f"Expected ({correct_latitude}, {correct_longitude}), got "
+                        f"({self.latitude}, {self.longitude})."
+                    )
+
+        if self.mine in mine_locations:
+            self.latitude = mine_locations[self.mine]["latitude"]
+            self.longitude = mine_locations[self.mine]["longitude"]
 
 
 class NRRIIronMinePerformanceComponent(PerformanceModelBaseClass):
@@ -83,6 +112,20 @@ class NRRIIronMinePerformanceComponent(PerformanceModelBaseClass):
             shape=self.n_timesteps,
             units="galUS/h",
             desc="Diesel feedstock into iron mine",
+        )
+
+        # add latitude and longitude inputs for mine location
+        self.add_input(
+            "latitude",
+            val=self.config.latitude,
+            units="deg",
+            desc="Latitude of the mine location",
+        )
+        self.add_input(
+            "longitude",
+            val=self.config.longitude,
+            units="deg",
+            desc="Longitude of the mine location",
         )
 
         self.add_output(
@@ -151,8 +194,7 @@ class NRRIIronMinePerformanceComponent(PerformanceModelBaseClass):
 
         coeff_fpath = ROOT_DIR / "converters" / "iron" / "nrri_ore" / "perf_coeffs.csv"
         # nrri ore performance model
-        coeff_df = pd.read_csv(coeff_fpath)
-        self.coeff_df = self.format_coeff_df(coeff_df, self.config.mine)
+        self.coeff_df = pd.read_csv(coeff_fpath)
 
     def format_coeff_df(self, coeff_df, mine):
         """Update the coefficient dataframe such that values are adjusted to standard units
@@ -227,6 +269,25 @@ class NRRIIronMinePerformanceComponent(PerformanceModelBaseClass):
         return coeff_df
 
     def compute(self, inputs, outputs):
+        mine_locations = {
+            "Hibbing": {"latitude": 47.53, "longitude": -92.91},
+            "Northshore": {"latitude": 47.29, "longitude": -91.25},
+            "United": {"latitude": 47.34, "longitude": -92.58},
+            "Minorca": {"latitude": 47.55, "longitude": -92.52},
+            "Tilden": {"latitude": 46.48, "longitude": -87.66},
+        }
+
+        # get mine location based on latitude and longitude inputs
+        mine_location = None
+        for mine, location in mine_locations.items():
+            if np.isclose(inputs["latitude"], location["latitude"]) and np.isclose(
+                inputs["longitude"], location["longitude"]
+            ):
+                mine_location = mine
+                break
+
+        self.coeff_df = self.format_coeff_df(self.coeff_df, mine_location)
+
         energy_per_process = {}
         natural_gas_per_process = {}
         diesel_per_process = {}

--- a/h2integrate/converters/iron/nrri_iron_mine.py
+++ b/h2integrate/converters/iron/nrri_iron_mine.py
@@ -285,6 +285,12 @@ class NRRIIronMinePerformanceComponent(PerformanceModelBaseClass):
             ):
                 mine_location = mine
                 break
+        if mine_location is None:
+            raise ValueError(
+                f"Latitude and longitude inputs do not match any known mine locations. "
+                f"Please check the inputs. Provided latitude: {inputs['latitude']}, "
+                f"longitude: {inputs['longitude']}."
+            )
 
         self.coeff_df = self.format_coeff_df(self.coeff_dataframe, mine_location)
 
@@ -629,6 +635,12 @@ class NRRIIronMineCostComponent(CostModelBaseClass):
             ):
                 mine_location = mine
                 break
+        if mine_location is None:
+            raise ValueError(
+                f"Latitude and longitude inputs do not match any known mine locations. "
+                f"Please check the inputs. Provided latitude: {inputs['latitude']}, "
+                f"longitude: {inputs['longitude']}."
+            )
 
         self.coeff_df = self.format_coeff_df(self.coeff_dataframe, mine_location)
 

--- a/h2integrate/converters/iron/nrri_iron_mine.py
+++ b/h2integrate/converters/iron/nrri_iron_mine.py
@@ -12,6 +12,30 @@ from h2integrate.core.model_baseclasses import CostModelBaseClass, PerformanceMo
 from h2integrate.tools.inflation.inflate import inflate_cpi
 
 
+MINE_LOCATIONS = {
+    "Hibbing": {"latitude": 47.53, "longitude": -92.91},
+    "Northshore": {"latitude": 47.29, "longitude": -91.25},
+    "United": {"latitude": 47.34, "longitude": -92.58},
+    "Minorca": {"latitude": 47.55, "longitude": -92.52},
+    "Tilden": {"latitude": 46.48, "longitude": -87.66},
+}
+
+
+def get_mine_from_coordinates(latitude, longitude):
+    """Return the mine matching the provided latitude and longitude."""
+    for mine, location in MINE_LOCATIONS.items():
+        if np.isclose(latitude, location["latitude"]) and np.isclose(
+            longitude, location["longitude"]
+        ):
+            return mine
+
+    raise ValueError(
+        f"Latitude and longitude inputs do not match any known mine locations. "
+        f"Please check the inputs. Provided latitude: {latitude}, "
+        f"longitude: {longitude}."
+    )
+
+
 @define(kw_only=True)
 class NRRIIronMinePerformanceConfig(BaseConfig):
     """Configuration class for NRRIIronMinePerformanceComponent.
@@ -35,28 +59,24 @@ class NRRIIronMinePerformanceConfig(BaseConfig):
     longitude: float = field(default=None)
 
     def __attrs_post_init__(self):
-        mine_locations = {
-            "Hibbing": {"latitude": 47.53, "longitude": -92.91},
-            "Northshore": {"latitude": 47.29, "longitude": -91.25},
-            "United": {"latitude": 47.34, "longitude": -92.58},
-            "Minorca": {"latitude": 47.55, "longitude": -92.52},
-            "Tilden": {"latitude": 46.48, "longitude": -87.66},
-        }
         if self.latitude is not None or self.longitude is not None:
             # check if the latitude and longitude are correct for the mine location
-            if self.mine in mine_locations:
-                correct_latitude = mine_locations[self.mine]["latitude"]
-                correct_longitude = mine_locations[self.mine]["longitude"]
-                if self.latitude != correct_latitude or self.longitude != correct_longitude:
-                    raise ValueError(
-                        f"Incorrect latitude and/or longitude for mine {self.mine}. "
-                        f"Expected ({correct_latitude}, {correct_longitude}), got "
-                        f"({self.latitude}, {self.longitude})."
-                    )
+            correct_latitude = MINE_LOCATIONS[self.mine]["latitude"]
+            correct_longitude = MINE_LOCATIONS[self.mine]["longitude"]
+            if (
+                self.latitude is None
+                or self.longitude is None
+                or not np.isclose(self.latitude, correct_latitude)
+                or not np.isclose(self.longitude, correct_longitude)
+            ):
+                raise ValueError(
+                    f"Incorrect latitude and/or longitude for mine {self.mine}. "
+                    f"Expected ({correct_latitude}, {correct_longitude}), got "
+                    f"({self.latitude}, {self.longitude})."
+                )
 
-        if self.mine in mine_locations:
-            self.latitude = mine_locations[self.mine]["latitude"]
-            self.longitude = mine_locations[self.mine]["longitude"]
+        self.latitude = MINE_LOCATIONS[self.mine]["latitude"]
+        self.longitude = MINE_LOCATIONS[self.mine]["longitude"]
 
 
 class NRRIIronMinePerformanceComponent(PerformanceModelBaseClass):
@@ -269,28 +289,8 @@ class NRRIIronMinePerformanceComponent(PerformanceModelBaseClass):
         return coeff_df
 
     def compute(self, inputs, outputs):
-        mine_locations = {
-            "Hibbing": {"latitude": 47.53, "longitude": -92.91},
-            "Northshore": {"latitude": 47.29, "longitude": -91.25},
-            "United": {"latitude": 47.34, "longitude": -92.58},
-            "Minorca": {"latitude": 47.55, "longitude": -92.52},
-            "Tilden": {"latitude": 46.48, "longitude": -87.66},
-        }
-
         # get mine location based on latitude and longitude inputs
-        mine_location = None
-        for mine, location in mine_locations.items():
-            if np.isclose(inputs["latitude"], location["latitude"]) and np.isclose(
-                inputs["longitude"], location["longitude"]
-            ):
-                mine_location = mine
-                break
-        if mine_location is None:
-            raise ValueError(
-                f"Latitude and longitude inputs do not match any known mine locations. "
-                f"Please check the inputs. Provided latitude: {inputs['latitude']}, "
-                f"longitude: {inputs['longitude']}."
-            )
+        mine_location = get_mine_from_coordinates(inputs["latitude"], inputs["longitude"])
 
         self.coeff_df = self.format_coeff_df(self.coeff_dataframe, mine_location)
 
@@ -465,28 +465,24 @@ class NRRIIronMineCostConfig(BaseConfig):
     longitude: float = field(default=None)
 
     def __attrs_post_init__(self):
-        mine_locations = {
-            "Hibbing": {"latitude": 47.53, "longitude": -92.91},
-            "Northshore": {"latitude": 47.29, "longitude": -91.25},
-            "United": {"latitude": 47.34, "longitude": -92.58},
-            "Minorca": {"latitude": 47.55, "longitude": -92.52},
-            "Tilden": {"latitude": 46.48, "longitude": -87.66},
-        }
         if self.latitude is not None or self.longitude is not None:
             # check if the latitude and longitude are correct for the mine location
-            if self.mine in mine_locations:
-                correct_latitude = mine_locations[self.mine]["latitude"]
-                correct_longitude = mine_locations[self.mine]["longitude"]
-                if self.latitude != correct_latitude or self.longitude != correct_longitude:
-                    raise ValueError(
-                        f"Incorrect latitude and/or longitude for mine {self.mine}. "
-                        f"Expected ({correct_latitude}, {correct_longitude}), got "
-                        f"({self.latitude}, {self.longitude})."
-                    )
+            correct_latitude = MINE_LOCATIONS[self.mine]["latitude"]
+            correct_longitude = MINE_LOCATIONS[self.mine]["longitude"]
+            if (
+                self.latitude is None
+                or self.longitude is None
+                or not np.isclose(self.latitude, correct_latitude)
+                or not np.isclose(self.longitude, correct_longitude)
+            ):
+                raise ValueError(
+                    f"Incorrect latitude and/or longitude for mine {self.mine}. "
+                    f"Expected ({correct_latitude}, {correct_longitude}), got "
+                    f"({self.latitude}, {self.longitude})."
+                )
 
-        if self.mine in mine_locations:
-            self.latitude = mine_locations[self.mine]["latitude"]
-            self.longitude = mine_locations[self.mine]["longitude"]
+        self.latitude = MINE_LOCATIONS[self.mine]["latitude"]
+        self.longitude = MINE_LOCATIONS[self.mine]["longitude"]
 
 
 class NRRIIronMineCostComponent(CostModelBaseClass):
@@ -619,28 +615,8 @@ class NRRIIronMineCostComponent(CostModelBaseClass):
         return coeff_df
 
     def compute(self, inputs, outputs, discrete_inputs, discrete_outputs):
-        mine_locations = {
-            "Hibbing": {"latitude": 47.53, "longitude": -92.91},
-            "Northshore": {"latitude": 47.29, "longitude": -91.25},
-            "United": {"latitude": 47.34, "longitude": -92.58},
-            "Minorca": {"latitude": 47.55, "longitude": -92.52},
-            "Tilden": {"latitude": 46.48, "longitude": -87.66},
-        }
-
         # get mine location based on latitude and longitude inputs
-        mine_location = None
-        for mine, location in mine_locations.items():
-            if np.isclose(inputs["latitude"], location["latitude"]) and np.isclose(
-                inputs["longitude"], location["longitude"]
-            ):
-                mine_location = mine
-                break
-        if mine_location is None:
-            raise ValueError(
-                f"Latitude and longitude inputs do not match any known mine locations. "
-                f"Please check the inputs. Provided latitude: {inputs['latitude']}, "
-                f"longitude: {inputs['longitude']}."
-            )
+        mine_location = get_mine_from_coordinates(inputs["latitude"], inputs["longitude"])
 
         self.coeff_df = self.format_coeff_df(self.coeff_dataframe, mine_location)
 

--- a/h2integrate/converters/iron/nrri_iron_mine.py
+++ b/h2integrate/converters/iron/nrri_iron_mine.py
@@ -194,7 +194,7 @@ class NRRIIronMinePerformanceComponent(PerformanceModelBaseClass):
 
         coeff_fpath = ROOT_DIR / "converters" / "iron" / "nrri_ore" / "perf_coeffs.csv"
         # nrri ore performance model
-        self.coeff_df = pd.read_csv(coeff_fpath)
+        self.coeff_dataframe = pd.read_csv(coeff_fpath)
 
     def format_coeff_df(self, coeff_df, mine):
         """Update the coefficient dataframe such that values are adjusted to standard units
@@ -286,7 +286,7 @@ class NRRIIronMinePerformanceComponent(PerformanceModelBaseClass):
                 mine_location = mine
                 break
 
-        self.coeff_df = self.format_coeff_df(self.coeff_df, mine_location)
+        self.coeff_df = self.format_coeff_df(self.coeff_dataframe, mine_location)
 
         energy_per_process = {}
         natural_gas_per_process = {}
@@ -299,7 +299,7 @@ class NRRIIronMinePerformanceComponent(PerformanceModelBaseClass):
         if system_capacity * 8760 > ref_pellets:
             msg = (
                 f"System capacity of {system_capacity} t/yr exceeds the reference pellet"
-                f" production of {ref_pellets} t/yr."
+                f" production of {ref_pellets/8760} t/yr."
                 f" This may lead to unrealistic results."
             )
             warnings.warn(msg, UserWarning)
@@ -440,6 +440,10 @@ class NRRIIronMineCostConfig(BaseConfig):
             "Minorca" or "Tilden"
         taconite_pellet_type (str): type of taconite pellets, options are "std" or "drg".
         cost_year (int): target dollar year to convert costs to.
+        latitude (float): latitude of the mine location. If not provided, it will be set
+            based on the mine name.
+        longitude (float): longitude of the mine location. If not provided, it will be set
+            based on the mine name.
     """
 
     mine: str = field(
@@ -451,6 +455,32 @@ class NRRIIronMineCostConfig(BaseConfig):
     # the cost model is based on costs from 2021 and can be adjusted to another cost year
     # using CPI adjustment.
     cost_year: int = field(converter=int, validator=(validators.ge(2010), validators.le(2024)))
+    latitude: float = field(default=None)
+    longitude: float = field(default=None)
+
+    def __attrs_post_init__(self):
+        mine_locations = {
+            "Hibbing": {"latitude": 47.53, "longitude": -92.91},
+            "Northshore": {"latitude": 47.29, "longitude": -91.25},
+            "United": {"latitude": 47.34, "longitude": -92.58},
+            "Minorca": {"latitude": 47.55, "longitude": -92.52},
+            "Tilden": {"latitude": 46.48, "longitude": -87.66},
+        }
+        if self.latitude is not None or self.longitude is not None:
+            # check if the latitude and longitude are correct for the mine location
+            if self.mine in mine_locations:
+                correct_latitude = mine_locations[self.mine]["latitude"]
+                correct_longitude = mine_locations[self.mine]["longitude"]
+                if self.latitude != correct_latitude or self.longitude != correct_longitude:
+                    raise ValueError(
+                        f"Incorrect latitude and/or longitude for mine {self.mine}. "
+                        f"Expected ({correct_latitude}, {correct_longitude}), got "
+                        f"({self.latitude}, {self.longitude})."
+                    )
+
+        if self.mine in mine_locations:
+            self.latitude = mine_locations[self.mine]["latitude"]
+            self.longitude = mine_locations[self.mine]["longitude"]
 
 
 class NRRIIronMineCostComponent(CostModelBaseClass):
@@ -507,10 +537,22 @@ class NRRIIronMineCostComponent(CostModelBaseClass):
             desc="Annual iron ore production",
         )
 
+        self.add_input(
+            "latitude",
+            val=self.config.latitude,
+            units="deg",
+            desc="Latitude of the mine location",
+        )
+        self.add_input(
+            "longitude",
+            val=self.config.longitude,
+            units="deg",
+            desc="Longitude of the mine location",
+        )
+
         coeff_fpath = ROOT_DIR / "converters" / "iron" / "nrri_ore" / "cost_coeffs.csv"
         # nrri ore cost model
-        coeff_df = pd.read_csv(coeff_fpath)
-        self.coeff_df = self.format_coeff_df(coeff_df, self.config.mine)
+        self.coeff_dataframe = pd.read_csv(coeff_fpath)
 
     def format_coeff_df(self, coeff_df, mine):
         """Update the coefficient dataframe such that values are adjusted to standard units
@@ -571,6 +613,25 @@ class NRRIIronMineCostComponent(CostModelBaseClass):
         return coeff_df
 
     def compute(self, inputs, outputs, discrete_inputs, discrete_outputs):
+        mine_locations = {
+            "Hibbing": {"latitude": 47.53, "longitude": -92.91},
+            "Northshore": {"latitude": 47.29, "longitude": -91.25},
+            "United": {"latitude": 47.34, "longitude": -92.58},
+            "Minorca": {"latitude": 47.55, "longitude": -92.52},
+            "Tilden": {"latitude": 46.48, "longitude": -87.66},
+        }
+
+        # get mine location based on latitude and longitude inputs
+        mine_location = None
+        for mine, location in mine_locations.items():
+            if np.isclose(inputs["latitude"], location["latitude"]) and np.isclose(
+                inputs["longitude"], location["longitude"]
+            ):
+                mine_location = mine
+                break
+
+        self.coeff_df = self.format_coeff_df(self.coeff_dataframe, mine_location)
+
         pellet_type = self.config.taconite_pellet_type
 
         # Get the capital cost for the reference design and scale to the modeled mine

--- a/h2integrate/converters/iron/simple_mine_perf_model.py
+++ b/h2integrate/converters/iron/simple_mine_perf_model.py
@@ -136,11 +136,11 @@ class SimpleIronMinePerformanceComponent(PerformanceModelBaseClass):
         coeff_df.loc[i_wlt, "Value"] = coeff_df.loc[i_wlt, "Value"] * dry_fraction
         coeff_df.loc[i_wlt, "Unit"] = "lt/yr"
 
-        # convert kWh/wet long ton to kWh/dry long ton
-        i_per_wlt = coeff_df[coeff_df["Unit"] == "kWh/LT pellet"].index.to_list()
-        coeff_df.loc[i_per_wlt, "Value"] = coeff_df.loc[i_per_wlt, "Value"] / dry_fraction
-        coeff_df.loc[i_per_wlt, "Unit"] = "kWh/lt"
-        coeff_df.loc[i_per_wlt, "Type"] = "energy use/pellet"
+        # update units to kWh/dry long ton
+        i = coeff_df[coeff_df["Unit"] == "kWh/LT pellet"].index.to_list()
+        coeff_df.loc[i, "Value"] = coeff_df.loc[i, "Value"]
+        coeff_df.loc[i, "Unit"] = "kWh/lt"
+        coeff_df.loc[i, "Type"] = "energy use/pellet"
 
         # convert units to standardized units
         unit_rename_mapper = {}

--- a/h2integrate/converters/iron/test/test_nrri_mine.py
+++ b/h2integrate/converters/iron/test/test_nrri_mine.py
@@ -117,7 +117,62 @@ def test_iron_mine_cost_outputs(plant_config, driver_config, iron_ore_config_mar
         assert total_opex == pytest.approx(7457805.0 * 89.3661325, rel=1e-3)
 
 
-@pytest.mark.regression
+@pytest.mark.unit
+def test_iron_mine_perf_lat_lon(plant_config, driver_config, iron_ore_config_martin_om, subtests):
+    prob = om.Problem()
+    iron_ore = NRRIIronMinePerformanceComponent(
+        plant_config=plant_config,
+        tech_config=iron_ore_config_martin_om,
+        driver_config=driver_config,
+    )
+    prob.model.add_subsystem("comp", iron_ore, promotes=["*"])
+    prob.setup()
+
+    hourly_electricity = 1000000
+    hourly_fuel = 50000
+    hourly_diesel = 1e7
+    ore_rated_capacity = 7457805 * 0.98 * 1.016
+
+    prob.set_val("comp.electricity_in", [hourly_electricity] * 8760, units="kW")
+    prob.set_val("comp.natural_gas_in", [hourly_fuel] * 8760, units="MMBtu/h")
+    prob.set_val("comp.diesel_in", [hourly_diesel] * 8760, units="galUS/h")
+    prob.set_val("comp.iron_ore_command_value", [ore_rated_capacity], units="t/h")
+
+    prob.set_val("comp.latitude", 47.53, units="deg")
+    prob.set_val("comp.longitude", -92.91, units="deg")
+
+    prob.run_model()
+
+    with subtests.test("pelletization elec"):
+        pel_elec = prob.get_val("comp.pelletization_electricity", units="kW")
+        assert np.sum(pel_elec) == pytest.approx(47.46 * 7457805 * 0.98, rel=1e-3)
+
+
+@pytest.mark.unit
+def test_iron_mine_lat_lon(plant_config, driver_config, iron_ore_config_martin_om, subtests):
+    plant_config["finance_parameters"]["cost_adjustment_parameters"]["target_dollar_year"] = 2021
+    prob = om.Problem()
+    iron_ore_cost = NRRIIronMineCostComponent(
+        plant_config=plant_config,
+        tech_config=iron_ore_config_martin_om,
+        driver_config=driver_config,
+    )
+    prob.model.add_subsystem("comp", iron_ore_cost, promotes=["*"])
+    prob.setup()
+
+    prob.set_val("comp.latitude", 47.53, units="deg")
+    prob.set_val("comp.longitude", -92.91, units="deg")
+
+    prob.set_val("comp.annual_iron_ore_produced", [7400230 * 1.016], units="t/yr")
+
+    prob.run_model()
+
+    with subtests.test("total_opex"):
+        total_opex = prob.get_val("comp.OpEx", units="USD/yr")
+        assert total_opex == pytest.approx(7400230.0 * 49.31140012, rel=1e-3)
+
+
+@pytest.mark.unit
 def test_adjusting_cost_year(plant_config, driver_config, iron_ore_config_martin_om, subtests):
     iron_ore_config_martin_om["model_inputs"]["shared_parameters"]["mine"] = "United"
     iron_ore_config_martin_om["model_inputs"]["cost_parameters"]["taconite_pellet_type"] = "drg"


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELETE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code highlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Update NRRI mine to allow lat/lon inputs
<!-- Describe your feature here. Please include any code snippets or examples in this section. -->
Previously, the NRRI mine only allowed the mine name to be input as a `str` in the `NRRIIronMinePerformanceConfig` and `NRRIIronMineCostConfig`. This limited the ability to use the parameter sweeps feature of H2I because only OpenMDAO `inputs` can be modified in a parameter sweep. 

The update added latitude and longitude as OpenMDAO inputs to both the `NRRIIronMinePerformanceComponent` and `NRRIIronMineCostComponent`. The `compute()` has been modified so that the mine is selected based on the input latitude and longitude. This feature is backwards compatable with the previous behavior by allowing the user to specifiy the mine in the  config and in the `__attrs_post_init__(self)` it selects the correct latitude and longitude for the site.

## Section 1: Type of Contribution
<!-- Check all that apply to help reviewers understand your contribution -->
- [x] Feature Enhancement
  - [ ] Framework
  - [ ] New Model
  - [x] Updated Model
  - [ ] Tools/Utilities
  - [ ] Other (please describe):
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] CI Changes
- [ ] Other (please describe):

## Section 2: Draft PR Checklist
<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
<!--Complete when opening a draft PR. -->
- [ ] Open draft PR
- [ ] Describe the feature that will be added
- [ ] Fill out TODO list steps
- [ ] Describe requested feedback from reviewers on draft PR
- [ ] Complete Section 8: New Model Checklist (if applicable)
<!-- Describe the feature in this PR and outline next steps -->
### TODO:
- [ ] Step 1
- [ ] Step 2

### Type of Reviewer Feedback Requested (on Draft PR)
<!-- Outline the feedback that would be helpful from reviewers while it's a draft PR -->
**Structural feedback**:

**Implementation feedback**:

**Other feedback**:

## Section 3: General PR Checklist
<!--Complete when converting draft PR to a merge-ready PR. -->
- [ ] PR description thoroughly describes the new feature, bug fix, etc.
- [ ] Added tests for new functionality or bug fixes
- [ ] Tests pass (If not, and this is expected, please elaborate in the Section 6: Test Results)
- [ ] Documentation
  - [ ] Docstrings are up-to-date
  - [ ] Related `docs/` files are up-to-date, or added when necessary
  - [ ] Documentation has been rebuilt successfully
  - [ ] Examples have been updated (if applicable)
- [ ] `CHANGELOG.md`
  - [ ] At least one complete sentence has been provided to describe the changes made in this PR
  - [ ] After the above, a hyperlink has been provided to the PR using the following format:
    "A complete thought. [PR XYZ]((https://github.com/NatLabRockies/H2Integrate/pull/XYZ)", where
    `XYZ` should be replaced with the actual number.

## Section 4: Related Issues
<!--If this PR relates to an existing GitHub issue, please link the issue and indicate whether this PR would fully or partially resolve that issue. Please also link any issues that were created due to this PR-->


## Section 5: Impacted Areas of the Software
<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why. Can exclude CHANGELOG.md, doc pages and supported_models.py.
-->
### Section 5.1: New Files
N/A

### Section 5.2: Modified Files
- `h2integrate/converters/iron/simple_mine_perf_model.py`
  - `format_coeff_df()`: Unit error in energy usage. Was dividing by WLT but the units were already in LTP.
- `examples/test/test_all_examples.py`
  - Test values changed because energy use for the mine was over calculated based on the units error. Thus, test values are lower.
- `h2integrate/converters/iron/nrri_iron_mine.py`
  - `NRRIIronMinePerformanceConfig` and `NRRIIronMineCostConfig`: Added latitude and longitude as arguments, default `None`. Added `__attrs_post_init__(self)`, that sets latitude and longitude based on mine name.
  - `NRRIIronMinePerformanceComponent` and `NRRIIronMineCostComponent`: Added `latitude` and `longitude` to inputs in the `setup()`. Moved the call `format_coeff_df()` to the `compute()` so it gets reinitialized per run (if the mine changes).

## Section 6: Additional Supporting Information
<!--Add any other context about the problem here.-->


## Section 7: Test Results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->

## Section 8 (Optional): New Model Checklist
<!-- Complete this section only if you checked "New Model" above -->
- [ ] **Model Structure**:
  - [ ] Follows established naming conventions outlined in `docs/developer_guide/coding_guidelines.md`
  - [ ] Used `attrs` class to define the `Config` to load in attributes for the model
    - [ ] If applicable: inherit from `BaseConfig` or `CostModelBaseConfig`
  - [ ] Added: `initialize()` method, `setup()` method, `compute()` method
    - [ ] If applicable: inherit from `CostModelBaseClass`
- [ ] **Integration**: Model has been properly integrated into H2Integrate
  - [ ] Add the new model to the appropriate `__init__.py` file to ensure it is properly imported and used in `supported_models.py`
  - [ ] Added to `supported_models.py`
  - [ ] If a new commodity_type is added, update `create_financial_model` in `h2integrate_model.py`
- [ ] **Tests**: Unit tests have been added for the new model
  - [ ] [Pytest-style unit tests](https://realpython.com/pytest-python-testing/)
  - [ ] Unit tests are in a "test" folder within the folder a new model was added to
  - [ ] If applicable add integration tests
- [ ] **Example**: If applicable, a working example demonstrating the new model has been created
  - [ ] Input file comments
  - [ ] Run file comments
  - [ ] Example has been tested and runs successfully in `test_all_examples.py`
- [ ] **Documentation**:
  - [ ] Write docstrings using the [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
  - [ ] Model added to the main models list in `docs/user_guide/model_overview.md`
    - [ ] Model documentation page added to the appropriate `docs/` section
    - [ ] `<model_name>.md` is added to the `_toc.yml`
  - [ ] Run `generate_class_hierarchy.py` to update the class hierarchy diagram in `docs/developer_guide/class_structure.md`





<!--
__ For NLR use __
Release checklist:
- [ ] Update the version in h2integrate/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NatLabRockies/H2Integrate repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
