### PR TITLE
Rename resource connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Bugfix in LCO breakdown function to include sales tax and typo-fix in commodity units extraction in ProFAST finance models [PR 867](https://github.com/NatLabRockies/H2Integrate/pull/867)
 - Expanded ability to connect site information (such as latitude and longitude) to technologies and added the transport cost model `LinearDistanceCostModel` [PR 865](https://github.com/NatLabRockies/H2Integrate/pull/865)
 - Enable the use of latitude and longitude to specify the mine location [PR 875](https://github.com/NatLabRockies/H2Integrate/pull/875)
+- Renamed the plant-config site connection key from `resource_to_tech_connections` to `site_to_resource_connections` to reflect site metadata use cases such as latitude and longitude. [PR 879](https://github.com/NatLabRockies/H2Integrate/pull/879)
 
 ## 0.9 [August 10, 2026]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Bugfix in LCO breakdown function to include sales tax and typo-fix in commodity units extraction in ProFAST finance models [PR 867](https://github.com/NatLabRockies/H2Integrate/pull/867)
 - Expanded ability to connect site information (such as latitude and longitude) to technologies and added the transport cost model `LinearDistanceCostModel` [PR 865](https://github.com/NatLabRockies/H2Integrate/pull/865)
 - Enable the use of latitude and longitude to specify the mine location [PR 875](https://github.com/NatLabRockies/H2Integrate/pull/875)
-- Renamed the plant-config site connection key from `resource_to_tech_connections` to `site_to_resource_connections` to reflect site metadata use cases such as latitude and longitude. [PR 879](https://github.com/NatLabRockies/H2Integrate/pull/879)
+- Renamed the plant-config site connection key from `resource_to_tech_connections` to `site_to_tech_connections` so it reflects both site metadata and technology connections such as latitude, longitude, and resource data. [PR 879](https://github.com/NatLabRockies/H2Integrate/pull/879)
 
 ## 0.9 [August 10, 2026]
 

--- a/docs/resource/resource_index.md
+++ b/docs/resource/resource_index.md
@@ -76,7 +76,7 @@ sites:
         resource_parameters:
           filename: river_data.csv
 
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the river resource to the run-of-river hydro technology
   - [site.river_resource, river, discharge]
 ```

--- a/docs/resource/resource_index.md
+++ b/docs/resource/resource_index.md
@@ -76,7 +76,7 @@ sites:
         resource_parameters:
           filename: river_data.csv
 
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the river resource to the run-of-river hydro technology
   - [site.river_resource, river, discharge]
 ```

--- a/docs/resource/wave_resource.md
+++ b/docs/resource/wave_resource.md
@@ -41,10 +41,10 @@ sites:
 
 The `resource_year` parameter is used to generate the hourly timestamp arrays (year, month, day, hour, minute) that are passed internally to the PySAM MhkWave model in timeseries mode.
 
-The wave resource outputs are connected to the wave performance model via `site_to_resource_connections` in `plant_config.yaml`:
+The wave resource outputs are connected to the wave performance model via `site_to_tech_connections` in `plant_config.yaml`:
 
 ```yaml
-site_to_resource_connections:
+site_to_tech_connections:
   - [site.wave_resource, wave, significant_wave_height]
   - [site.wave_resource, wave, energy_period]
 ```

--- a/docs/resource/wave_resource.md
+++ b/docs/resource/wave_resource.md
@@ -41,10 +41,10 @@ sites:
 
 The `resource_year` parameter is used to generate the hourly timestamp arrays (year, month, day, hour, minute) that are passed internally to the PySAM MhkWave model in timeseries mode.
 
-The wave resource outputs are connected to the wave performance model via `resource_to_tech_connections` in `plant_config.yaml`:
+The wave resource outputs are connected to the wave performance model via `site_to_resource_connections` in `plant_config.yaml`:
 
 ```yaml
-resource_to_tech_connections:
+site_to_resource_connections:
   - [site.wave_resource, wave, significant_wave_height]
   - [site.wave_resource, wave, energy_period]
 ```

--- a/docs/user_guide/defining_sites_and_resources.md
+++ b/docs/user_guide/defining_sites_and_resources.md
@@ -1,7 +1,7 @@
 (defining_sites_connect_resource)=
 # Defining Sites and Connecting Resources
 
-This guide covers how to define sites, resource models, amd connect resource data to technologies within H2Integrate, focusing on the `sites` configuration and the `resource_to_tech_connections` configuration defined in the plant configuration file.
+This guide covers how to define sites, resource models, and connect site and resource data to technologies within H2Integrate, focusing on the `sites` configuration and the `site_to_resource_connections` configuration defined in the plant configuration file.
 
 ## Defining Sites and Resources
 
@@ -23,16 +23,16 @@ sites:
 
 Further information on the available resource models can be found [here](https://h2integrate.readthedocs.io/en/latest/resource/resource_index.html)
 
-## Resource to technology connections overview
+## Site-to-resource connections overview
 
-The `resource_to_tech_connections` section in your plant configuration file defines how different technologies are connected to sites and the resource data for that site.
+The `site_to_resource_connections` section in your plant configuration file defines how technologies are connected to site data and resource outputs for that site. This includes resource data such as wind or solar time series and site parameters such as latitude and longitude.
 The H2I framework establishes the necessary OpenMDAO connections between your sites and technologies based on these specifications.
 
 ### Connecting Resource Data to Technologies
 Resource to technology connections are defined as an array of 3-element arrays in your `plant_config.yaml`:
 
 ```yaml
-resource_to_tech_connections: [
+site_to_resource_connections: [
   [site_name.resource_name, tech_name, variable_name],
   ['wind_site.wind_resource', 'wind', 'wind_resource_data'],
 ]
@@ -52,7 +52,7 @@ Some technologies may have calculations that depend on the latitude and longitud
 #### 3-element connections (direct connections)
 ##### Same shared location names
 ```yaml
-resource_to_tech_connections:
+site_to_resource_connections:
 # connect the latitude and longitude from site_name to destination_tech
   - ["site_name", "destination_tech", "latitude"]
   - ["site_name", "destination_tech", "longitude"]
@@ -64,7 +64,7 @@ resource_to_tech_connections:
 
 ##### Different shared parameter names
 ```yaml
-resource_to_tech_connections:
+site_to_resource_connections:
   - ["site_name", "destination_tech", ["latitude", "dest_latitude_parameter"]]
   - ["site_name", "destination_tech", ["longitude", "dest_longitude_parameter"]]
 ```
@@ -77,7 +77,7 @@ resource_to_tech_connections:
 An example using the `LinearDistanceCostModel` which is a technology named `transport_cost` is shown below:
 
 ```yaml
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the source site location to the transport cost model
   - ["source_site", "transport_cost", ["latitude", "source_latitude"]]
   - ["source_site", "transport_cost", ["longitude", "source_longitude"]]
@@ -91,7 +91,7 @@ resource_to_tech_connections:
 The following sections will go over various examples and use-cases for defining sites and resource models.
 
 ### Single site without resource
-If none of the technologies in the technology configuration require resource data, then you do not need to include `resource_to_tech_connections` in the plant configuration file and `resources` do not need to be defined for the site defined under `sites`.
+If none of the technologies in the technology configuration require resource data, then you do not need to include `site_to_resource_connections` in the plant configuration file and `resources` do not need to be defined for the site defined under `sites`.
 
 An example `sites` configuration may look like:
 ```yaml
@@ -106,7 +106,7 @@ Some examples that define a single site without resource data are:
 - `examples/11_hybrid_energy_plant/plant_config.yaml`
 
 ### Single site with a single resource
-If a single technology (named `"wind"` in this example) requires resource data, then the `sites` configuration and `resource_to_tech_connections` may look like:
+If a single technology (named `"wind"` in this example) requires resource data, then the `sites` configuration and `site_to_resource_connections` may look like:
 ```yaml
 sites:
   wind_site: #site name
@@ -117,7 +117,7 @@ sites:
         resource_model: "wind_toolkit_v2_api"
         resource_parameters:
           resource_year: 2012
-resource_to_tech_connections: [
+site_to_resource_connections: [
   # formatted as [site_name.resource_name, tech_name, variable_name],
   ['wind_site.wind_resource', 'wind', 'wind_resource_data'],
 ]
@@ -132,7 +132,7 @@ Some examples that define a single site with a single resource are:
 - `examples/22_site_doe/plant_config.yaml`
 
 ### Single site with multiple resources
-If multiple technologies (named `"wind"` and `"solar"` in this example) require resource data from the same location, then the `sites` configuration and `resource_to_tech_connections` may look like:
+If multiple technologies (named `"wind"` and `"solar"` in this example) require resource data from the same location, then the `sites` configuration and `site_to_resource_connections` may look like:
 ```yaml
 sites:
   site_A: #site name
@@ -147,7 +147,7 @@ sites:
         resource_model: "goes_aggregated_solar_v4_api"
         resource_parameters:
           resource_year: 2012
-resource_to_tech_connections: [
+site_to_resource_connections: [
   # formatted as [site_name.resource_name, tech_name, variable_name],
   ['site_A.wind_resource', 'wind', 'wind_resource_data'],
   ['site_A.solar_resource', 'solar', 'solar_resource_data'],
@@ -161,7 +161,7 @@ Some examples that define a single site with multiple resources are:
 - `examples/23_solar_wind_ng_demand/plant_config.yaml`
 
 ### Multiple sites with resources
-If multiple technologies, named `"distributed_wind_plant"` and `"utility_wind_plant"` in this example (examples/26_floris), require resource data from different locations, then the `sites` configuration and `resource_to_tech_connections` may look like:
+If multiple technologies, named `"distributed_wind_plant"` and `"utility_wind_plant"` in this example (examples/26_floris), require resource data from different locations, then the `sites` configuration and `site_to_resource_connections` may look like:
 ```yaml
 sites:
   distributed_wind_site: #name of distributed site
@@ -180,7 +180,7 @@ sites:
         resource_model: "wind_toolkit_v2_api"
         resource_parameters:
           resource_year: 2012
-resource_to_tech_connections: [
+site_to_resource_connections: [
   # formatted as [site_name.resource_name, tech_name, variable_name],
   ['distributed_wind_site.wind_resource', 'distributed_wind_plant', 'wind_resource_data'],
   ['utility_wind_site.wind_resource', 'utility_wind_plant', 'wind_resource_data'],

--- a/docs/user_guide/defining_sites_and_resources.md
+++ b/docs/user_guide/defining_sites_and_resources.md
@@ -1,7 +1,7 @@
 (defining_sites_connect_resource)=
 # Defining Sites and Connecting Resources
 
-This guide covers how to define sites, resource models, and connect site and resource data to technologies within H2Integrate, focusing on the `sites` configuration and the `site_to_resource_connections` configuration defined in the plant configuration file.
+This guide covers how to define sites, resource models, and connect site and resource data to technologies within H2Integrate, focusing on the `sites` configuration and the `site_to_tech_connections` configuration defined in the plant configuration file.
 
 ## Defining Sites and Resources
 
@@ -25,14 +25,14 @@ Further information on the available resource models can be found [here](https:/
 
 ## Site-to-resource connections overview
 
-The `site_to_resource_connections` section in your plant configuration file defines how technologies are connected to site data and resource outputs for that site. This includes resource data such as wind or solar time series and site parameters such as latitude and longitude.
+The `site_to_tech_connections` section in your plant configuration file defines how technologies are connected to site data and resource outputs for that site. This includes resource data such as wind or solar time series and site parameters such as latitude and longitude.
 The H2I framework establishes the necessary OpenMDAO connections between your sites and technologies based on these specifications.
 
 ### Connecting Resource Data to Technologies
 Resource to technology connections are defined as an array of 3-element arrays in your `plant_config.yaml`:
 
 ```yaml
-site_to_resource_connections: [
+site_to_tech_connections: [
   [site_name.resource_name, tech_name, variable_name],
   ['wind_site.wind_resource', 'wind', 'wind_resource_data'],
 ]
@@ -52,7 +52,7 @@ Some technologies may have calculations that depend on the latitude and longitud
 #### 3-element connections (direct connections)
 ##### Same shared location names
 ```yaml
-site_to_resource_connections:
+site_to_tech_connections:
 # connect the latitude and longitude from site_name to destination_tech
   - ["site_name", "destination_tech", "latitude"]
   - ["site_name", "destination_tech", "longitude"]
@@ -64,7 +64,7 @@ site_to_resource_connections:
 
 ##### Different shared parameter names
 ```yaml
-site_to_resource_connections:
+site_to_tech_connections:
   - ["site_name", "destination_tech", ["latitude", "dest_latitude_parameter"]]
   - ["site_name", "destination_tech", ["longitude", "dest_longitude_parameter"]]
 ```
@@ -77,7 +77,7 @@ site_to_resource_connections:
 An example using the `LinearDistanceCostModel` which is a technology named `transport_cost` is shown below:
 
 ```yaml
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the source site location to the transport cost model
   - ["source_site", "transport_cost", ["latitude", "source_latitude"]]
   - ["source_site", "transport_cost", ["longitude", "source_longitude"]]
@@ -91,7 +91,7 @@ site_to_resource_connections:
 The following sections will go over various examples and use-cases for defining sites and resource models.
 
 ### Single site without resource
-If none of the technologies in the technology configuration require resource data, then you do not need to include `site_to_resource_connections` in the plant configuration file and `resources` do not need to be defined for the site defined under `sites`.
+If none of the technologies in the technology configuration require resource data, then you do not need to include `site_to_tech_connections` in the plant configuration file and `resources` do not need to be defined for the site defined under `sites`.
 
 An example `sites` configuration may look like:
 ```yaml
@@ -106,7 +106,7 @@ Some examples that define a single site without resource data are:
 - `examples/11_hybrid_energy_plant/plant_config.yaml`
 
 ### Single site with a single resource
-If a single technology (named `"wind"` in this example) requires resource data, then the `sites` configuration and `site_to_resource_connections` may look like:
+If a single technology (named `"wind"` in this example) requires resource data, then the `sites` configuration and `site_to_tech_connections` may look like:
 ```yaml
 sites:
   wind_site: #site name
@@ -117,7 +117,7 @@ sites:
         resource_model: "wind_toolkit_v2_api"
         resource_parameters:
           resource_year: 2012
-site_to_resource_connections: [
+site_to_tech_connections: [
   # formatted as [site_name.resource_name, tech_name, variable_name],
   ['wind_site.wind_resource', 'wind', 'wind_resource_data'],
 ]
@@ -132,7 +132,7 @@ Some examples that define a single site with a single resource are:
 - `examples/22_site_doe/plant_config.yaml`
 
 ### Single site with multiple resources
-If multiple technologies (named `"wind"` and `"solar"` in this example) require resource data from the same location, then the `sites` configuration and `site_to_resource_connections` may look like:
+If multiple technologies (named `"wind"` and `"solar"` in this example) require resource data from the same location, then the `sites` configuration and `site_to_tech_connections` may look like:
 ```yaml
 sites:
   site_A: #site name
@@ -147,7 +147,7 @@ sites:
         resource_model: "goes_aggregated_solar_v4_api"
         resource_parameters:
           resource_year: 2012
-site_to_resource_connections: [
+site_to_tech_connections: [
   # formatted as [site_name.resource_name, tech_name, variable_name],
   ['site_A.wind_resource', 'wind', 'wind_resource_data'],
   ['site_A.solar_resource', 'solar', 'solar_resource_data'],
@@ -161,7 +161,7 @@ Some examples that define a single site with multiple resources are:
 - `examples/23_solar_wind_ng_demand/plant_config.yaml`
 
 ### Multiple sites with resources
-If multiple technologies, named `"distributed_wind_plant"` and `"utility_wind_plant"` in this example (examples/26_floris), require resource data from different locations, then the `sites` configuration and `site_to_resource_connections` may look like:
+If multiple technologies, named `"distributed_wind_plant"` and `"utility_wind_plant"` in this example (examples/26_floris), require resource data from different locations, then the `sites` configuration and `site_to_tech_connections` may look like:
 ```yaml
 sites:
   distributed_wind_site: #name of distributed site
@@ -180,7 +180,7 @@ sites:
         resource_model: "wind_toolkit_v2_api"
         resource_parameters:
           resource_year: 2012
-site_to_resource_connections: [
+site_to_tech_connections: [
   # formatted as [site_name.resource_name, tech_name, variable_name],
   ['distributed_wind_site.wind_resource', 'distributed_wind_plant', 'wind_resource_data'],
   ['utility_wind_site.wind_resource', 'utility_wind_plant', 'wind_resource_data'],

--- a/docs/user_guide/how_to_set_up_an_analysis.md
+++ b/docs/user_guide/how_to_set_up_an_analysis.md
@@ -119,7 +119,7 @@ The first entry in the list is the technology that is providing the input to the
 If the list is length 4, then the third entry in the list is what's being passed via a transporter of the type defined in the fourth entry.
 If the list is length 3, then the third entry in the list is what is connected directly between the technologies.
 
-The `resource_to_tech_connections` section defines how resources (like wind or solar data) are connected to the technologies that use them.
+The `site_to_resource_connections` section defines how resources (like wind or solar data) are connected to the technologies that use them.
 
 ```{note}
 For more information on how to define and interpret technology interconnections, see the {ref}`connecting_technologies:overview` page.

--- a/docs/user_guide/how_to_set_up_an_analysis.md
+++ b/docs/user_guide/how_to_set_up_an_analysis.md
@@ -119,7 +119,7 @@ The first entry in the list is the technology that is providing the input to the
 If the list is length 4, then the third entry in the list is what's being passed via a transporter of the type defined in the fourth entry.
 If the list is length 3, then the third entry in the list is what is connected directly between the technologies.
 
-The `site_to_resource_connections` section defines how resources (like wind or solar data) are connected to the technologies that use them.
+The `site_to_tech_connections` section defines how resources (like wind or solar data) are connected to the technologies that use them.
 
 ```{note}
 For more information on how to define and interpret technology interconnections, see the {ref}`connecting_technologies:overview` page.

--- a/examples/01_onshore_steel_mn/plant_config.yaml
+++ b/examples/01_onshore_steel_mn/plant_config.yaml
@@ -36,7 +36,7 @@ technology_interconnections:
 tech_to_dispatch_connections:
   - [combiner, battery]
   - [battery, battery]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
   - [site.solar_resource, solar, solar_resource_data]

--- a/examples/01_onshore_steel_mn/plant_config.yaml
+++ b/examples/01_onshore_steel_mn/plant_config.yaml
@@ -36,7 +36,7 @@ technology_interconnections:
 tech_to_dispatch_connections:
   - [combiner, battery]
   - [battery, battery]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
   - [site.solar_resource, solar, solar_resource_data]

--- a/examples/02_texas_ammonia/plant_config.yaml
+++ b/examples/02_texas_ammonia/plant_config.yaml
@@ -37,7 +37,7 @@ technology_interconnections:
 tech_to_dispatch_connections:
   - [combiner, battery]
   - [battery, battery]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
   - [site.solar_resource, solar, solar_resource_data]

--- a/examples/02_texas_ammonia/plant_config.yaml
+++ b/examples/02_texas_ammonia/plant_config.yaml
@@ -37,7 +37,7 @@ technology_interconnections:
 tech_to_dispatch_connections:
   - [combiner, battery]
   - [battery, battery]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
   - [site.solar_resource, solar, solar_resource_data]

--- a/examples/03_methanol/co2_hydrogenation/plant_config_co2h.yaml
+++ b/examples/03_methanol/co2_hydrogenation/plant_config_co2h.yaml
@@ -25,7 +25,7 @@ technology_interconnections:
   - [electrolyzer, methanol, hydrogen, pipe]
   - [finance_subgroup_electricity, methanol, LCOE]
   - [finance_subgroup_hydrogen, methanol, LCOH]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
   - [site.solar_resource, solar, solar_resource_data]

--- a/examples/03_methanol/co2_hydrogenation/plant_config_co2h.yaml
+++ b/examples/03_methanol/co2_hydrogenation/plant_config_co2h.yaml
@@ -25,7 +25,7 @@ technology_interconnections:
   - [electrolyzer, methanol, hydrogen, pipe]
   - [finance_subgroup_electricity, methanol, LCOE]
   - [finance_subgroup_hydrogen, methanol, LCOH]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
   - [site.solar_resource, solar, solar_resource_data]

--- a/examples/03_methanol/co2_hydrogenation_doc/plant_config_co2h.yaml
+++ b/examples/03_methanol/co2_hydrogenation_doc/plant_config_co2h.yaml
@@ -27,7 +27,7 @@ technology_interconnections:
   - [co2_storage, co2_combiner, co2, pipe]
   # connect the co2 supply to the methanol system
   - [co2_combiner, methanol, co2, pipe]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 plant:

--- a/examples/03_methanol/co2_hydrogenation_doc/plant_config_co2h.yaml
+++ b/examples/03_methanol/co2_hydrogenation_doc/plant_config_co2h.yaml
@@ -27,7 +27,7 @@ technology_interconnections:
   - [co2_storage, co2_combiner, co2, pipe]
   # connect the co2 supply to the methanol system
   - [co2_combiner, methanol, co2, pipe]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 plant:

--- a/examples/05_wind_h2_opt/plant_config.yaml
+++ b/examples/05_wind_h2_opt/plant_config.yaml
@@ -18,7 +18,7 @@ plant:
 technology_interconnections:
   - [wind, electrolyzer, electricity, cable]
   # etc
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 finance_parameters:

--- a/examples/05_wind_h2_opt/plant_config.yaml
+++ b/examples/05_wind_h2_opt/plant_config.yaml
@@ -18,7 +18,7 @@ plant:
 technology_interconnections:
   - [wind, electrolyzer, electricity, cable]
   # etc
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 finance_parameters:

--- a/examples/06_custom_tech/plant_config.yaml
+++ b/examples/06_custom_tech/plant_config.yaml
@@ -18,6 +18,6 @@ plant:
 technology_interconnections:
   - [wind, paper_mill, electricity, cable]
   # etc
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]

--- a/examples/06_custom_tech/plant_config.yaml
+++ b/examples/06_custom_tech/plant_config.yaml
@@ -18,6 +18,6 @@ plant:
 technology_interconnections:
   - [wind, paper_mill, electricity, cable]
   # etc
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]

--- a/examples/07_run_of_river_plant/plant_config.yaml
+++ b/examples/07_run_of_river_plant/plant_config.yaml
@@ -18,7 +18,7 @@ sites:
 technology_interconnections: []
 # resource interconnections
 # array of arrays containing left-to-right resource interconnections;
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the river resource to the run-of-river hydro technology
   - [site.river_resource, river, discharge]
 plant:

--- a/examples/07_run_of_river_plant/plant_config.yaml
+++ b/examples/07_run_of_river_plant/plant_config.yaml
@@ -18,7 +18,7 @@ sites:
 technology_interconnections: []
 # resource interconnections
 # array of arrays containing left-to-right resource interconnections;
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the river resource to the run-of-river hydro technology
   - [site.river_resource, river, discharge]
 plant:

--- a/examples/08_wind_electrolyzer/plant_config.yaml
+++ b/examples/08_wind_electrolyzer/plant_config.yaml
@@ -12,7 +12,7 @@ sites:
 plant:
   plant_life: 30
 technology_interconnections: [[wind, electrolyzer, electricity, cable]]
-resource_to_tech_connections: [[site.wind_resource, wind, wind_resource_data]]
+site_to_resource_connections: [[site.wind_resource, wind, wind_resource_data]]
 finance_parameters:
   finance_groups:
     custom_model:

--- a/examples/08_wind_electrolyzer/plant_config.yaml
+++ b/examples/08_wind_electrolyzer/plant_config.yaml
@@ -12,7 +12,7 @@ sites:
 plant:
   plant_life: 30
 technology_interconnections: [[wind, electrolyzer, electricity, cable]]
-site_to_resource_connections: [[site.wind_resource, wind, wind_resource_data]]
+site_to_tech_connections: [[site.wind_resource, wind, wind_resource_data]]
 finance_parameters:
   finance_groups:
     custom_model:

--- a/examples/09_co2/direct_ocean_capture/plant_config.yaml
+++ b/examples/09_co2/direct_ocean_capture/plant_config.yaml
@@ -32,7 +32,7 @@ technology_interconnections:
 tech_to_dispatch_connections:
   - [combiner, battery]
   - [battery, battery]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
   # connect the wave resource to the wave technology

--- a/examples/09_co2/direct_ocean_capture/plant_config.yaml
+++ b/examples/09_co2/direct_ocean_capture/plant_config.yaml
@@ -32,7 +32,7 @@ technology_interconnections:
 tech_to_dispatch_connections:
   - [combiner, battery]
   - [battery, battery]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
   # connect the wave resource to the wave technology

--- a/examples/09_co2/ocean_alkalinity_enhancement/plant_config.yaml
+++ b/examples/09_co2/ocean_alkalinity_enhancement/plant_config.yaml
@@ -24,7 +24,7 @@ technology_interconnections:
 tech_to_dispatch_connections:
   - [wind, battery]
   - [battery, battery]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 plant:

--- a/examples/09_co2/ocean_alkalinity_enhancement/plant_config.yaml
+++ b/examples/09_co2/ocean_alkalinity_enhancement/plant_config.yaml
@@ -24,7 +24,7 @@ technology_interconnections:
 tech_to_dispatch_connections:
   - [wind, battery]
   - [battery, battery]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 plant:

--- a/examples/09_co2/ocean_alkalinity_enhancement_financials/plant_config_financials.yaml
+++ b/examples/09_co2/ocean_alkalinity_enhancement_financials/plant_config_financials.yaml
@@ -20,7 +20,7 @@ technology_interconnections:
   - [finance_subgroup_electricity, oae, LCOE]
   - [wind, oae, [annual_electricity_produced, annual_input_electricity]]
   # etc
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 finance_parameters:

--- a/examples/09_co2/ocean_alkalinity_enhancement_financials/plant_config_financials.yaml
+++ b/examples/09_co2/ocean_alkalinity_enhancement_financials/plant_config_financials.yaml
@@ -20,7 +20,7 @@ technology_interconnections:
   - [finance_subgroup_electricity, oae, LCOE]
   - [wind, oae, [annual_electricity_produced, annual_input_electricity]]
   # etc
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 finance_parameters:

--- a/examples/10_electrolyzer_om/plant_config.yaml
+++ b/examples/10_electrolyzer_om/plant_config.yaml
@@ -18,7 +18,7 @@ plant:
 technology_interconnections:
   - [wind, electrolyzer, electricity, cable]
   # etc
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 finance_parameters:

--- a/examples/10_electrolyzer_om/plant_config.yaml
+++ b/examples/10_electrolyzer_om/plant_config.yaml
@@ -18,7 +18,7 @@ plant:
 technology_interconnections:
   - [wind, electrolyzer, electricity, cable]
   # etc
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 finance_parameters:

--- a/examples/11_hybrid_energy_plant/plant_config.yaml
+++ b/examples/11_hybrid_energy_plant/plant_config.yaml
@@ -30,7 +30,7 @@ technology_interconnections:
 tech_to_dispatch_connections:
   - [combiner, battery]
   - [battery, battery]
-resource_to_tech_connections:
+site_to_resource_connections:
   - [site.wind_resource, wind, wind_resource_data]
   - [site.solar_resource, solar, solar_resource_data]
 finance_parameters:

--- a/examples/11_hybrid_energy_plant/plant_config.yaml
+++ b/examples/11_hybrid_energy_plant/plant_config.yaml
@@ -30,7 +30,7 @@ technology_interconnections:
 tech_to_dispatch_connections:
   - [combiner, battery]
   - [battery, battery]
-site_to_resource_connections:
+site_to_tech_connections:
   - [site.wind_resource, wind, wind_resource_data]
   - [site.solar_resource, solar, solar_resource_data]
 finance_parameters:

--- a/examples/12_ammonia_synloop/plant_config.yaml
+++ b/examples/12_ammonia_synloop/plant_config.yaml
@@ -40,7 +40,7 @@ technology_interconnections:
 tech_to_dispatch_connections:
   - [combiner, battery]
   - [battery, battery]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
   - [site.solar_resource, solar, solar_resource_data]

--- a/examples/12_ammonia_synloop/plant_config.yaml
+++ b/examples/12_ammonia_synloop/plant_config.yaml
@@ -40,7 +40,7 @@ technology_interconnections:
 tech_to_dispatch_connections:
   - [combiner, battery]
   - [battery, battery]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
   - [site.solar_resource, solar, solar_resource_data]

--- a/examples/13_dispatch_for_electrolyzer/plant_config.yaml
+++ b/examples/13_dispatch_for_electrolyzer/plant_config.yaml
@@ -25,7 +25,7 @@ technology_interconnections:
   - [elec_combiner, elec_load_demand, electricity, cable]
   # connect the electricity supplied to the demand to the electrolyzer
   - [elec_load_demand, electrolyzer, electricity, cable]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, distributed_wind_plant, wind_resource_data]
   - [site.solar_resource, distributed_pv, solar_resource_data]

--- a/examples/13_dispatch_for_electrolyzer/plant_config.yaml
+++ b/examples/13_dispatch_for_electrolyzer/plant_config.yaml
@@ -25,7 +25,7 @@ technology_interconnections:
   - [elec_combiner, elec_load_demand, electricity, cable]
   # connect the electricity supplied to the demand to the electrolyzer
   - [elec_load_demand, electrolyzer, electricity, cable]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, distributed_wind_plant, wind_resource_data]
   - [site.solar_resource, distributed_pv, solar_resource_data]

--- a/examples/14_wind_hydrogen_dispatch/inputs/plant_config.yaml
+++ b/examples/14_wind_hydrogen_dispatch/inputs/plant_config.yaml
@@ -21,7 +21,7 @@ technology_interconnections:
   - [h2_storage, h2_combiner, hydrogen, pipe]
   # subtract hydrogen production from hydrogen demand
   - [h2_combiner, h2_load_demand, hydrogen, pipe]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 plant:

--- a/examples/14_wind_hydrogen_dispatch/inputs/plant_config.yaml
+++ b/examples/14_wind_hydrogen_dispatch/inputs/plant_config.yaml
@@ -21,7 +21,7 @@ technology_interconnections:
   - [h2_storage, h2_combiner, hydrogen, pipe]
   # subtract hydrogen production from hydrogen demand
   - [h2_combiner, h2_load_demand, hydrogen, pipe]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 plant:

--- a/examples/15_wind_solar_electrolyzer/plant_config.yaml
+++ b/examples/15_wind_solar_electrolyzer/plant_config.yaml
@@ -49,7 +49,7 @@ technology_interconnections:
   - [finance_subgroup_electricity, grid_buy, ['LCOE[0]', 'electricity_buy_price[0:8760]']]
   # 2. Buy from the grid exactly the electricity the electrolyzer consumes:
   - [electrolyzer, grid_buy, [electricity_consumed, electricity_set_point]]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [wind_site.wind_resource, wind, wind_resource_data]
   - [solar_site.solar_resource, solar, solar_resource_data]

--- a/examples/15_wind_solar_electrolyzer/plant_config.yaml
+++ b/examples/15_wind_solar_electrolyzer/plant_config.yaml
@@ -49,7 +49,7 @@ technology_interconnections:
   - [finance_subgroup_electricity, grid_buy, ['LCOE[0]', 'electricity_buy_price[0:8760]']]
   # 2. Buy from the grid exactly the electricity the electrolyzer consumes:
   - [electrolyzer, grid_buy, [electricity_consumed, electricity_set_point]]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [wind_site.wind_resource, wind, wind_resource_data]
   - [solar_site.solar_resource, solar, solar_resource_data]

--- a/examples/16_natural_gas/plant_config.yaml
+++ b/examples/16_natural_gas/plant_config.yaml
@@ -31,7 +31,7 @@ technology_interconnections:
   # connect natural gas and combined solar+battery generation to finance combiner
   - [elec_combiner, fin_combiner, electricity, cable]
   - [natural_gas_plant, fin_combiner, electricity, cable]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.solar_resource, solar, solar_resource_data]
 plant:

--- a/examples/16_natural_gas/plant_config.yaml
+++ b/examples/16_natural_gas/plant_config.yaml
@@ -31,7 +31,7 @@ technology_interconnections:
   # connect natural gas and combined solar+battery generation to finance combiner
   - [elec_combiner, fin_combiner, electricity, cable]
   - [natural_gas_plant, fin_combiner, electricity, cable]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.solar_resource, solar, solar_resource_data]
 plant:

--- a/examples/17_splitter_wind_doc_h2/plant_config.yaml
+++ b/examples/17_splitter_wind_doc_h2/plant_config.yaml
@@ -19,7 +19,7 @@ technology_interconnections:
   - [wind, electricity_splitter, electricity, cable]
   - [electricity_splitter, doc, electricity, cable]
   - [electricity_splitter, electrolyzer, electricity, cable]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 finance_parameters:

--- a/examples/17_splitter_wind_doc_h2/plant_config.yaml
+++ b/examples/17_splitter_wind_doc_h2/plant_config.yaml
@@ -19,7 +19,7 @@ technology_interconnections:
   - [wind, electricity_splitter, electricity, cable]
   - [electricity_splitter, doc, electricity, cable]
   - [electricity_splitter, electrolyzer, electricity, cable]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 finance_parameters:

--- a/examples/18_pyomo_heuristic_dispatch/plant_config.yaml
+++ b/examples/18_pyomo_heuristic_dispatch/plant_config.yaml
@@ -28,7 +28,7 @@ technology_interconnections:
 tech_to_dispatch_connections:
   - [wind, battery]
   - [battery, battery]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 finance_parameters:

--- a/examples/18_pyomo_heuristic_dispatch/plant_config.yaml
+++ b/examples/18_pyomo_heuristic_dispatch/plant_config.yaml
@@ -28,7 +28,7 @@ technology_interconnections:
 tech_to_dispatch_connections:
   - [wind, battery]
   - [battery, battery]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 finance_parameters:

--- a/examples/19_simple_dispatch/plant_config.yaml
+++ b/examples/19_simple_dispatch/plant_config.yaml
@@ -23,7 +23,7 @@ technology_interconnections:
   # subtract electricity production from electricity demand
   - [elec_combiner, electrical_load_demand, electricity, cable]
   # etc
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 finance_parameters:

--- a/examples/19_simple_dispatch/plant_config.yaml
+++ b/examples/19_simple_dispatch/plant_config.yaml
@@ -23,7 +23,7 @@ technology_interconnections:
   # subtract electricity production from electricity demand
   - [elec_combiner, electrical_load_demand, electricity, cable]
   # etc
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 finance_parameters:

--- a/examples/20_solar_electrolyzer_doe/plant_config.yaml
+++ b/examples/20_solar_electrolyzer_doe/plant_config.yaml
@@ -14,7 +14,7 @@ sites:
 technology_interconnections:
   - [solar, electrolyzer, electricity, cable]
                                                      # connect solar power to electrolyzer
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the solar resource to the solar technology
   - [site.solar_resource, solar, solar_resource_data]
 plant:

--- a/examples/20_solar_electrolyzer_doe/plant_config.yaml
+++ b/examples/20_solar_electrolyzer_doe/plant_config.yaml
@@ -14,7 +14,7 @@ sites:
 technology_interconnections:
   - [solar, electrolyzer, electricity, cable]
                                                      # connect solar power to electrolyzer
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the solar resource to the solar technology
   - [site.solar_resource, solar, solar_resource_data]
 plant:

--- a/examples/22_site_doe/plant_config.yaml
+++ b/examples/22_site_doe/plant_config.yaml
@@ -12,7 +12,7 @@ sites:
   interconnection_site:
     latitude: 34.126
     longitude: -99.144
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the solar resource to the solar technology
   - [site.solar_resource, solar, solar_resource_data]
   # connect the solar resource site to the transport cost model

--- a/examples/22_site_doe/plant_config.yaml
+++ b/examples/22_site_doe/plant_config.yaml
@@ -12,7 +12,7 @@ sites:
   interconnection_site:
     latitude: 34.126
     longitude: -99.144
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the solar resource to the solar technology
   - [site.solar_resource, solar, solar_resource_data]
   # connect the solar resource site to the transport cost model

--- a/examples/23_solar_wind_ng_demand/plant_config.yaml
+++ b/examples/23_solar_wind_ng_demand/plant_config.yaml
@@ -30,7 +30,7 @@ technology_interconnections:
   # give remaining load demand to natural gas plant
   - [combiner, fin_combiner, electricity, cable]
   - [natural_gas_plant, fin_combiner, electricity, cable]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
   - [site.solar_resource, solar, solar_resource_data]

--- a/examples/23_solar_wind_ng_demand/plant_config.yaml
+++ b/examples/23_solar_wind_ng_demand/plant_config.yaml
@@ -30,7 +30,7 @@ technology_interconnections:
   # give remaining load demand to natural gas plant
   - [combiner, fin_combiner, electricity, cable]
   - [natural_gas_plant, fin_combiner, electricity, cable]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
   - [site.solar_resource, solar, solar_resource_data]

--- a/examples/24_solar_battery_grid/plant_config.yaml
+++ b/examples/24_solar_battery_grid/plant_config.yaml
@@ -32,7 +32,7 @@ technology_interconnections:
   # combine electricity generated from solar+battery and electricity bought from grid
   - [bat_combiner, combiner, electricity, cable]
   - [grid_buy, combiner, electricity, cable]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.solar_resource, solar, solar_resource_data]
 plant:

--- a/examples/24_solar_battery_grid/plant_config.yaml
+++ b/examples/24_solar_battery_grid/plant_config.yaml
@@ -32,7 +32,7 @@ technology_interconnections:
   # combine electricity generated from solar+battery and electricity bought from grid
   - [bat_combiner, combiner, electricity, cable]
   - [grid_buy, combiner, electricity, cable]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.solar_resource, solar, solar_resource_data]
 plant:

--- a/examples/26_floris/plant_config.yaml
+++ b/examples/26_floris/plant_config.yaml
@@ -22,7 +22,7 @@ technology_interconnections:
   - [utility_wind_plant, combiner, electricity, cable]
                                                               # source_tech, dest_tech, transport_item, transport_type = connection
   - [distributed_wind_plant, combiner, electricity, cable]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource at the distributed_wind_site to the distributed_wind_plant technology
   - [distributed_wind_site.wind_resource, distributed_wind_plant, wind_resource_data]
   # connect the wind resource at the utility_wind_site to the utility_wind_plant technology

--- a/examples/26_floris/plant_config.yaml
+++ b/examples/26_floris/plant_config.yaml
@@ -22,7 +22,7 @@ technology_interconnections:
   - [utility_wind_plant, combiner, electricity, cable]
                                                               # source_tech, dest_tech, transport_item, transport_type = connection
   - [distributed_wind_plant, combiner, electricity, cable]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource at the distributed_wind_site to the distributed_wind_plant technology
   - [distributed_wind_site.wind_resource, distributed_wind_plant, wind_resource_data]
   # connect the wind resource at the utility_wind_site to the utility_wind_plant technology

--- a/examples/27_site_doe_diff/plant_config.yaml
+++ b/examples/27_site_doe_diff/plant_config.yaml
@@ -17,7 +17,7 @@ sites:
         resource_model: GOESAggregatedSolarAPI
         resource_parameters:
           resource_year: 2012
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [wind_site.wind_resource, wind, wind_resource_data]
   # connect the solar resource to the solar technology

--- a/examples/27_site_doe_diff/plant_config.yaml
+++ b/examples/27_site_doe_diff/plant_config.yaml
@@ -17,7 +17,7 @@ sites:
         resource_model: GOESAggregatedSolarAPI
         resource_parameters:
           resource_year: 2012
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [wind_site.wind_resource, wind, wind_resource_data]
   # connect the solar resource to the solar technology

--- a/examples/29_wind_ard/h2i_inputs/plant_config.yaml
+++ b/examples/29_wind_ard/h2i_inputs/plant_config.yaml
@@ -24,7 +24,7 @@ technology_interconnections:
   # subtract electricity production from electricity demand
   - [elec_combiner, electrical_load_demand, electricity, cable]
   # etc
-site_to_resource_connections:
+site_to_tech_connections:
   # The wind resource is handled strictly by Ard in this example,
   # so only the solar resource connection is included here
   - [site.solar_resource, solar, solar_resource_data]

--- a/examples/29_wind_ard/h2i_inputs/plant_config.yaml
+++ b/examples/29_wind_ard/h2i_inputs/plant_config.yaml
@@ -24,7 +24,7 @@ technology_interconnections:
   # subtract electricity production from electricity demand
   - [elec_combiner, electrical_load_demand, electricity, cable]
   # etc
-resource_to_tech_connections:
+site_to_resource_connections:
   # The wind resource is handled strictly by Ard in this example,
   # so only the solar resource connection is included here
   - [site.solar_resource, solar, solar_resource_data]

--- a/examples/30_pyomo_optimized_dispatch/plant_config.yaml
+++ b/examples/30_pyomo_optimized_dispatch/plant_config.yaml
@@ -28,7 +28,7 @@ technology_interconnections:
 tech_to_dispatch_connections:
   - [wind, battery]
   - [battery, battery]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 finance_parameters:

--- a/examples/30_pyomo_optimized_dispatch/plant_config.yaml
+++ b/examples/30_pyomo_optimized_dispatch/plant_config.yaml
@@ -28,7 +28,7 @@ technology_interconnections:
 tech_to_dispatch_connections:
   - [wind, battery]
   - [battery, battery]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 finance_parameters:

--- a/examples/31_tidal/plant_config.yaml
+++ b/examples/31_tidal/plant_config.yaml
@@ -19,7 +19,7 @@ sites:
 technology_interconnections: []
 # resource interconnections
 # array of arrays containing left-to-right resource interconnections;
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the tidal resource to the tidal technology
   - [site.tidal_resource, tidal, tidal_velocity]
 plant:

--- a/examples/31_tidal/plant_config.yaml
+++ b/examples/31_tidal/plant_config.yaml
@@ -19,7 +19,7 @@ sites:
 technology_interconnections: []
 # resource interconnections
 # array of arrays containing left-to-right resource interconnections;
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the tidal resource to the tidal technology
   - [site.tidal_resource, tidal, tidal_velocity]
 plant:

--- a/examples/35_system_level_control/battery_with_controller/plant_config.yaml
+++ b/examples/35_system_level_control/battery_with_controller/plant_config.yaml
@@ -26,7 +26,7 @@ technology_interconnections:
   - [natural_gas_plant, combiner, electricity, cable]
   # combined supply to demand
   - [combiner, electrical_load_demand, electricity, cable]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 plant:

--- a/examples/35_system_level_control/battery_with_controller/plant_config.yaml
+++ b/examples/35_system_level_control/battery_with_controller/plant_config.yaml
@@ -26,7 +26,7 @@ technology_interconnections:
   - [natural_gas_plant, combiner, electricity, cable]
   # combined supply to demand
   - [combiner, electrical_load_demand, electricity, cable]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 plant:

--- a/examples/35_system_level_control/complex_profit_max/plant_config.yaml
+++ b/examples/35_system_level_control/complex_profit_max/plant_config.yaml
@@ -30,7 +30,7 @@ technology_interconnections:
   - [grid_buy, fin_combiner, electricity, cable]
   # Final combiner delivers to demand
   - [fin_combiner, electrical_load_demand, electricity, cable]
-resource_to_tech_connections:
+site_to_resource_connections:
   - [site.wind_resource, wind, wind_resource_data]
   - [site.solar_resource, solar, solar_resource_data]
 plant:

--- a/examples/35_system_level_control/complex_profit_max/plant_config.yaml
+++ b/examples/35_system_level_control/complex_profit_max/plant_config.yaml
@@ -30,7 +30,7 @@ technology_interconnections:
   - [grid_buy, fin_combiner, electricity, cable]
   # Final combiner delivers to demand
   - [fin_combiner, electrical_load_demand, electricity, cable]
-site_to_resource_connections:
+site_to_tech_connections:
   - [site.wind_resource, wind, wind_resource_data]
   - [site.solar_resource, solar, solar_resource_data]
 plant:

--- a/examples/35_system_level_control/no_battery/plant_config.yaml
+++ b/examples/35_system_level_control/no_battery/plant_config.yaml
@@ -22,7 +22,7 @@ technology_interconnections:
   - [natural_gas_plant, combiner, electricity, cable]
   # subtract the combined electricity production from the demand
   - [combiner, electrical_load_demand, electricity, cable]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 plant:

--- a/examples/35_system_level_control/no_battery/plant_config.yaml
+++ b/examples/35_system_level_control/no_battery/plant_config.yaml
@@ -22,7 +22,7 @@ technology_interconnections:
   - [natural_gas_plant, combiner, electricity, cable]
   # subtract the combined electricity production from the demand
   - [combiner, electrical_load_demand, electricity, cable]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 plant:

--- a/examples/35_system_level_control/profit_maximization/plant_config.yaml
+++ b/examples/35_system_level_control/profit_maximization/plant_config.yaml
@@ -16,7 +16,7 @@ technology_interconnections:
   - [battery, fin_combiner, electricity, cable]
   - [natural_gas_plant, fin_combiner, electricity, cable]
   - [fin_combiner, electrical_load_demand, electricity, cable]
-resource_to_tech_connections:
+site_to_resource_connections:
   - [site.wind_resource, wind, wind_resource_data]
 plant:
   plant_life: 30

--- a/examples/35_system_level_control/profit_maximization/plant_config.yaml
+++ b/examples/35_system_level_control/profit_maximization/plant_config.yaml
@@ -16,7 +16,7 @@ technology_interconnections:
   - [battery, fin_combiner, electricity, cable]
   - [natural_gas_plant, fin_combiner, electricity, cable]
   - [fin_combiner, electrical_load_demand, electricity, cable]
-site_to_resource_connections:
+site_to_tech_connections:
   - [site.wind_resource, wind, wind_resource_data]
 plant:
   plant_life: 30

--- a/examples/35_system_level_control/upstream_demand/plant_config.yaml
+++ b/examples/35_system_level_control/upstream_demand/plant_config.yaml
@@ -35,7 +35,7 @@ technology_interconnections:
   # send hydrogen to load
   - [h2_combiner, h2_load_demand, hydrogen, pipe]
   # combined supply to demand
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 plant:

--- a/examples/35_system_level_control/upstream_demand/plant_config.yaml
+++ b/examples/35_system_level_control/upstream_demand/plant_config.yaml
@@ -35,7 +35,7 @@ technology_interconnections:
   # send hydrogen to load
   - [h2_combiner, h2_load_demand, hydrogen, pipe]
   # combined supply to demand
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 plant:

--- a/examples/35_system_level_control/yes_battery/plant_config.yaml
+++ b/examples/35_system_level_control/yes_battery/plant_config.yaml
@@ -26,7 +26,7 @@ technology_interconnections:
   - [natural_gas_plant, combiner, electricity, cable]
   # combined supply to demand
   - [combiner, electrical_load_demand, electricity, cable]
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 plant:

--- a/examples/35_system_level_control/yes_battery/plant_config.yaml
+++ b/examples/35_system_level_control/yes_battery/plant_config.yaml
@@ -26,7 +26,7 @@ technology_interconnections:
   - [natural_gas_plant, combiner, electricity, cable]
   # combined supply to demand
   - [combiner, electrical_load_demand, electricity, cable]
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 plant:

--- a/examples/35_system_level_control/yes_hydrogen/plant_config.yaml
+++ b/examples/35_system_level_control/yes_hydrogen/plant_config.yaml
@@ -33,7 +33,7 @@ technology_interconnections:
   # send hydrogen to load
   - [h2_combiner, h2_load_demand, hydrogen, pipe]
   # combined supply to demand
-resource_to_tech_connections:
+site_to_resource_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 plant:

--- a/examples/35_system_level_control/yes_hydrogen/plant_config.yaml
+++ b/examples/35_system_level_control/yes_hydrogen/plant_config.yaml
@@ -33,7 +33,7 @@ technology_interconnections:
   # send hydrogen to load
   - [h2_combiner, h2_load_demand, hydrogen, pipe]
   # combined supply to demand
-site_to_resource_connections:
+site_to_tech_connections:
   # connect the wind resource to the wind technology
   - [site.wind_resource, wind, wind_resource_data]
 plant:

--- a/examples/36_nuclear_reactor_htse/plant_config.yaml
+++ b/examples/36_nuclear_reactor_htse/plant_config.yaml
@@ -22,7 +22,7 @@ technology_interconnections:
   - [electrical_load_demand, grid_sell, [unused_electricity_out, electricity_set_point]]
   - [electrical_load_demand, grid_sell, [unused_electricity_out, electricity_in]]
 tech_to_dispatch_connections: []
-resource_to_tech_connections: []
+site_to_resource_connections: []
 finance_parameters:
   finance_groups:
     nuclear_finance:

--- a/examples/36_nuclear_reactor_htse/plant_config.yaml
+++ b/examples/36_nuclear_reactor_htse/plant_config.yaml
@@ -22,7 +22,7 @@ technology_interconnections:
   - [electrical_load_demand, grid_sell, [unused_electricity_out, electricity_set_point]]
   - [electrical_load_demand, grid_sell, [unused_electricity_out, electricity_in]]
 tech_to_dispatch_connections: []
-site_to_resource_connections: []
+site_to_tech_connections: []
 finance_parameters:
   finance_groups:
     nuclear_finance:

--- a/h2integrate/converters/combustion_machines/test/test_turbine_simple_cycle.py
+++ b/h2integrate/converters/combustion_machines/test/test_turbine_simple_cycle.py
@@ -103,7 +103,7 @@ def test_demo_case(subtests):
         "technology_interconnections": [
             ["ng_feedstock", "ng", "natural_gas", "pipe"],
         ],
-        "site_to_resource_connections": [
+        "site_to_tech_connections": [
             ["site.solar_resource", "ng", "solar_resource_data"],
         ],
     }

--- a/h2integrate/converters/combustion_machines/test/test_turbine_simple_cycle.py
+++ b/h2integrate/converters/combustion_machines/test/test_turbine_simple_cycle.py
@@ -103,7 +103,7 @@ def test_demo_case(subtests):
         "technology_interconnections": [
             ["ng_feedstock", "ng", "natural_gas", "pipe"],
         ],
-        "resource_to_tech_connections": [
+        "site_to_resource_connections": [
             ["site.solar_resource", "ng", "solar_resource_data"],
         ],
     }

--- a/h2integrate/core/h2integrate_model.py
+++ b/h2integrate/core/h2integrate_model.py
@@ -1766,7 +1766,7 @@ class H2IntegrateModel:
                 err_msg = f"Invalid connection: {connection}"
                 raise ValueError(err_msg)
 
-        resource_to_tech_connections = self.plant_config.get("resource_to_tech_connections", [])
+        site_to_resource_connections = self.plant_config.get("site_to_resource_connections", [])
 
         if "sites" in self.plant_config:
             resource_models = {}
@@ -1774,7 +1774,7 @@ class H2IntegrateModel:
                 for resource_key, resource_params in site_grp_inputs.get("resources", {}).items():
                     resource_models[f"{site_grp}.{resource_key}"] = resource_params
 
-            resource_source_connections = [c[0] for c in resource_to_tech_connections]
+            resource_source_connections = [c[0] for c in site_to_resource_connections]
             # Check if there is a missing resource to tech connection or missing resource model
             if len(resource_models) != len(resource_source_connections):
                 if len(resource_models) > len(resource_source_connections):
@@ -1787,8 +1787,8 @@ class H2IntegrateModel:
                         msg = (
                             "Some resources are not connected to a technology. Resource models "
                             f"{non_connected_resource} are not included in "
-                            "`resource_to_tech_connections`. Please connect these resources "
-                            "to their technologies under `resource_to_tech_connections` in "
+                            "`site_to_resource_connections`. Please connect these resources "
+                            "to their technologies under `site_to_resource_connections` in "
                             "the plant config file."
                         )
                         raise ValueError(msg)
@@ -1804,13 +1804,13 @@ class H2IntegrateModel:
                         msg = (
                             "Missing resource(s) are not defined but are connected to a"
                             f" technology. Missing resource(s) are {missing_resource}. "
-                            "Please check ``resource_to_tech_connections`` in the plant"
+                            "Please check ``site_to_resource_connections`` in the plant"
                             " config file or add the missing resources"
                             " to plant_config['site']['resources']."
                         )
                         raise ValueError(msg)
 
-            for connection in resource_to_tech_connections:
+            for connection in site_to_resource_connections:
                 if len(connection) != 3:
                     err_msg = f"Invalid resource to tech connection: {connection}"
                     raise ValueError(err_msg)
@@ -1856,7 +1856,7 @@ class H2IntegrateModel:
 
                     # If latitude is connected, make sure longitude is also connected
                     other_connection = [resource_name, tech_name, other_variable]
-                    if other_connection not in resource_to_tech_connections:
+                    if other_connection not in site_to_resource_connections:
                         msg = (
                             f"{site_parameter} is connected between {resource_name} and "
                             f"{tech_name}, but {other_loc_var} is not. Please ensure that "

--- a/h2integrate/core/h2integrate_model.py
+++ b/h2integrate/core/h2integrate_model.py
@@ -1766,7 +1766,7 @@ class H2IntegrateModel:
                 err_msg = f"Invalid connection: {connection}"
                 raise ValueError(err_msg)
 
-        site_to_resource_connections = self.plant_config.get("site_to_resource_connections", [])
+        site_to_tech_connections = self.plant_config.get("site_to_tech_connections", [])
 
         if "sites" in self.plant_config:
             resource_models = {}
@@ -1774,7 +1774,7 @@ class H2IntegrateModel:
                 for resource_key, resource_params in site_grp_inputs.get("resources", {}).items():
                     resource_models[f"{site_grp}.{resource_key}"] = resource_params
 
-            resource_source_connections = [c[0] for c in site_to_resource_connections]
+            resource_source_connections = [c[0] for c in site_to_tech_connections]
             # Check if there is a missing resource to tech connection or missing resource model
             if len(resource_models) != len(resource_source_connections):
                 if len(resource_models) > len(resource_source_connections):
@@ -1787,8 +1787,8 @@ class H2IntegrateModel:
                         msg = (
                             "Some resources are not connected to a technology. Resource models "
                             f"{non_connected_resource} are not included in "
-                            "`site_to_resource_connections`. Please connect these resources "
-                            "to their technologies under `site_to_resource_connections` in "
+                            "`site_to_tech_connections`. Please connect these resources "
+                            "to their technologies under `site_to_tech_connections` in "
                             "the plant config file."
                         )
                         raise ValueError(msg)
@@ -1804,13 +1804,13 @@ class H2IntegrateModel:
                         msg = (
                             "Missing resource(s) are not defined but are connected to a"
                             f" technology. Missing resource(s) are {missing_resource}. "
-                            "Please check ``site_to_resource_connections`` in the plant"
+                            "Please check ``site_to_tech_connections`` in the plant"
                             " config file or add the missing resources"
                             " to plant_config['site']['resources']."
                         )
                         raise ValueError(msg)
 
-            for connection in site_to_resource_connections:
+            for connection in site_to_tech_connections:
                 if len(connection) != 3:
                     err_msg = f"Invalid resource to tech connection: {connection}"
                     raise ValueError(err_msg)
@@ -1856,7 +1856,7 @@ class H2IntegrateModel:
 
                     # If latitude is connected, make sure longitude is also connected
                     other_connection = [resource_name, tech_name, other_variable]
-                    if other_connection not in site_to_resource_connections:
+                    if other_connection not in site_to_tech_connections:
                         msg = (
                             f"{site_parameter} is connected between {resource_name} and "
                             f"{tech_name}, but {other_loc_var} is not. Please ensure that "

--- a/h2integrate/core/inputs/plant_schema.yaml
+++ b/h2integrate/core/inputs/plant_schema.yaml
@@ -93,7 +93,7 @@ properties:
       items:
         type: [string, array]
         description: Technology names and connection types
-  resource_to_tech_connections:
+  site_to_resource_connections:
     type: array
     description: Array of arrays representing resource to technology connections
     items:

--- a/h2integrate/core/inputs/plant_schema.yaml
+++ b/h2integrate/core/inputs/plant_schema.yaml
@@ -93,7 +93,7 @@ properties:
       items:
         type: [string, array]
         description: Technology names and connection types
-  site_to_resource_connections:
+  site_to_tech_connections:
     type: array
     description: Array of arrays representing resource to technology connections
     items:

--- a/h2integrate/core/test/test_framework.py
+++ b/h2integrate/core/test/test_framework.py
@@ -936,7 +936,7 @@ def test_resource_connection_error_missing_connection(temp_dir):
     plant_config_data = load_plant_yaml(temp_plant_config)
 
     # Remove resource to tech connection
-    plant_config_data.pop("site_to_resource_connections")
+    plant_config_data.pop("site_to_tech_connections")
 
     # Save the modified tech_config YAML back
     with temp_plant_config.open("w") as f:
@@ -1016,11 +1016,11 @@ def test_no_resource_connection_error_resource_to_multiple_techs(temp_dir):
     # Add a second wind technology
     wind_tech = tech_config["technologies"]["wind"]
     tech_config["technologies"].update({"wind_plant2": wind_tech})
-    site_to_resource_connections = [
+    site_to_tech_connections = [
         ["site.wind_resource", "wind", "wind_resource_data"],
         ["site.wind_resource", "wind_plant2", "wind_resource_data"],
     ]
-    plant_config["site_to_resource_connections"] = site_to_resource_connections
+    plant_config["site_to_tech_connections"] = site_to_tech_connections
     input_config = {
         "plant_config": plant_config,
         "technology_config": tech_config,
@@ -1109,14 +1109,14 @@ def test_reports_turned_off(temp_dir):
 
 
 @pytest.mark.unit
-def test_invalid_site_to_resource_connections(subtests):
+def test_invalid_site_to_tech_connections(subtests):
     driver_config = load_driver_yaml(EXAMPLE_DIR / "01_onshore_steel_mn" / "driver_config.yaml")
     tech_config = load_tech_yaml(EXAMPLE_DIR / "01_onshore_steel_mn" / "tech_config.yaml")
     plant_config = load_plant_yaml(EXAMPLE_DIR / "01_onshore_steel_mn" / "plant_config.yaml")
-    valid_connection = plant_config.pop("site_to_resource_connections")
+    valid_connection = plant_config.pop("site_to_tech_connections")
 
     invalid_connection = ["site", "wind", ["latitude", "dest_longitude"]]
-    plant_config["site_to_resource_connections"] = [*valid_connection, invalid_connection]
+    plant_config["site_to_tech_connections"] = [*valid_connection, invalid_connection]
     h2i_config = {
         "driver_config": driver_config,
         "technology_config": tech_config,
@@ -1131,8 +1131,8 @@ def test_invalid_site_to_resource_connections(subtests):
 
     # Connecting latitude but missing connection for longitude
     valid_but_missing_connection = ["site", "wind", ["latitude", "dest_latitude"]]
-    plant_config["site_to_resource_connections"] = [*valid_connection, valid_but_missing_connection]
-    h2i_config["plant_config"]["site_to_resource_connections"]
+    plant_config["site_to_tech_connections"] = [*valid_connection, valid_but_missing_connection]
+    h2i_config["plant_config"]["site_to_tech_connections"]
 
     with subtests.test("Test missing connection for longitude (3rd element is list)"):
         expected_msg_part = "latitude is connected between site and wind, but longitude is not."
@@ -1142,8 +1142,8 @@ def test_invalid_site_to_resource_connections(subtests):
 
     # Connecting latitude but missing connection for longitude
     valid_but_missing_connection = ["site", "wind", "longitude"]
-    plant_config["site_to_resource_connections"] = [*valid_connection, valid_but_missing_connection]
-    h2i_config["plant_config"]["site_to_resource_connections"]
+    plant_config["site_to_tech_connections"] = [*valid_connection, valid_but_missing_connection]
+    h2i_config["plant_config"]["site_to_tech_connections"]
 
     with subtests.test("Test missing connection for latitude"):
         expected_msg_part = "longitude is connected between site and wind, but latitude is not."

--- a/h2integrate/core/test/test_framework.py
+++ b/h2integrate/core/test/test_framework.py
@@ -936,7 +936,7 @@ def test_resource_connection_error_missing_connection(temp_dir):
     plant_config_data = load_plant_yaml(temp_plant_config)
 
     # Remove resource to tech connection
-    plant_config_data.pop("resource_to_tech_connections")
+    plant_config_data.pop("site_to_resource_connections")
 
     # Save the modified tech_config YAML back
     with temp_plant_config.open("w") as f:
@@ -1016,11 +1016,11 @@ def test_no_resource_connection_error_resource_to_multiple_techs(temp_dir):
     # Add a second wind technology
     wind_tech = tech_config["technologies"]["wind"]
     tech_config["technologies"].update({"wind_plant2": wind_tech})
-    resource_to_tech_connections = [
+    site_to_resource_connections = [
         ["site.wind_resource", "wind", "wind_resource_data"],
         ["site.wind_resource", "wind_plant2", "wind_resource_data"],
     ]
-    plant_config["resource_to_tech_connections"] = resource_to_tech_connections
+    plant_config["site_to_resource_connections"] = site_to_resource_connections
     input_config = {
         "plant_config": plant_config,
         "technology_config": tech_config,
@@ -1109,14 +1109,14 @@ def test_reports_turned_off(temp_dir):
 
 
 @pytest.mark.unit
-def test_invalid_resource_to_tech_connections(subtests):
+def test_invalid_site_to_resource_connections(subtests):
     driver_config = load_driver_yaml(EXAMPLE_DIR / "01_onshore_steel_mn" / "driver_config.yaml")
     tech_config = load_tech_yaml(EXAMPLE_DIR / "01_onshore_steel_mn" / "tech_config.yaml")
     plant_config = load_plant_yaml(EXAMPLE_DIR / "01_onshore_steel_mn" / "plant_config.yaml")
-    valid_connection = plant_config.pop("resource_to_tech_connections")
+    valid_connection = plant_config.pop("site_to_resource_connections")
 
     invalid_connection = ["site", "wind", ["latitude", "dest_longitude"]]
-    plant_config["resource_to_tech_connections"] = [*valid_connection, invalid_connection]
+    plant_config["site_to_resource_connections"] = [*valid_connection, invalid_connection]
     h2i_config = {
         "driver_config": driver_config,
         "technology_config": tech_config,
@@ -1131,8 +1131,8 @@ def test_invalid_resource_to_tech_connections(subtests):
 
     # Connecting latitude but missing connection for longitude
     valid_but_missing_connection = ["site", "wind", ["latitude", "dest_latitude"]]
-    plant_config["resource_to_tech_connections"] = [*valid_connection, valid_but_missing_connection]
-    h2i_config["plant_config"]["resource_to_tech_connections"]
+    plant_config["site_to_resource_connections"] = [*valid_connection, valid_but_missing_connection]
+    h2i_config["plant_config"]["site_to_resource_connections"]
 
     with subtests.test("Test missing connection for longitude (3rd element is list)"):
         expected_msg_part = "latitude is connected between site and wind, but longitude is not."
@@ -1142,8 +1142,8 @@ def test_invalid_resource_to_tech_connections(subtests):
 
     # Connecting latitude but missing connection for longitude
     valid_but_missing_connection = ["site", "wind", "longitude"]
-    plant_config["resource_to_tech_connections"] = [*valid_connection, valid_but_missing_connection]
-    h2i_config["plant_config"]["resource_to_tech_connections"]
+    plant_config["site_to_resource_connections"] = [*valid_connection, valid_but_missing_connection]
+    h2i_config["plant_config"]["site_to_resource_connections"]
 
     with subtests.test("Test missing connection for latitude"):
         expected_msg_part = "longitude is connected between site and wind, but latitude is not."


### PR DESCRIPTION
# Rename plant-config site connections to `site_to_tech_connections`

This change renames the plant-config key from `resource_to_tech_connections` to `site_to_tech_connections` and updates the validation, examples, and docs to reflect that these connections cover both site metadata (such as latitude and longitude) and technology inputs that receive resource or site-based values.

## Section 1: Type of Contribution
- [x] Feature Enhancement
  - [x] Framework
  - [ ] New Model
  - [ ] Updated Model
  - [ ] Tools/Utilities
  - [ ] Other (please describe):
- [ ] Bug Fix
- [x] Documentation Update
- [ ] CI Changes
- [ ] Other (please describe):

## Section 2: Draft PR Checklist
- [x] Open draft PR
- [x] Describe the feature that will be added
- [x] Fill out TODO list steps
- [ ] Describe requested feedback from reviewers on draft PR
- [ ] Complete Section 8: New Model Checklist (if applicable)

### TODO:
- [x] Rename the config key across the repo
- [x] Update examples and documentation to the new naming
- [x] Add changelog entry

### Type of Reviewer Feedback Requested (on Draft PR)
**Structural feedback**:

**Implementation feedback**:

**Other feedback**:

## Section 3: General PR Checklist
- [x] PR description thoroughly describes the new feature, bug fix, etc.
- [x] Added tests for new functionality or bug fixes
- [x] Tests pass (If not, and this is expected, please elaborate in the Section 6: Test Results)
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related docs/ files are up-to-date, or added when necessary
  - [ ] Documentation has been rebuilt successfully
  - [x] Examples have been updated (if applicable)
- [x] CHANGELOG.md
  - [x] At least one complete sentence has been provided to describe the changes made in this PR
  - [x] After the above, a hyperlink has been provided to the PR using the following format:
    "A complete thought. [PR XYZ]((https://github.com/NatLabRockies/H2Integrate/pull/XYZ)", where
    `XYZ` should be replaced with the actual number.

## Section 4: Related Issues
Resolves #868 

## Section 5: Impacted Areas of the Software
### Section 5.1: New Files
- N/A

### Section 5.2: Modified Files
- [docs/user_guide/defining_sites_and_resources.md](docs/user_guide/defining_sites_and_resources.md)
  - Updated the site resource connection docs to the new key and clarified that the config covers site metadata as well as resource data.
- [h2integrate/core/h2integrate_model.py](h2integrate/core/h2integrate_model.py)
  - Updated the plant-config validation to read the renamed site-to-tech connection key.
- [h2integrate/core/inputs/plant_schema.yaml](h2integrate/core/inputs/plant_schema.yaml)
  - Updated the schema definition to match the renamed configuration entry.
- [examples/](examples/)
  - Renamed the plant config key in the example YAML files to keep them consistent with the framework.
- [CHANGELOG.md](CHANGELOG.md)
  - Added the unreleased changelog note for the rename.

## Section 6: Additional Supporting Information
This is a naming and contract update for the plant configuration. It clarifies that site metadata and resource outputs are both covered by the same connection list.

## Section 7: Test Results, if applicable


## Section 8 (Optional): New Model Checklist
N/A
