### PR TITLE
Check for extraneous and missing `tech_to_dispatch_connections`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Expanded ability to connect site information (such as latitude and longitude) to technologies and added the transport cost model `LinearDistanceCostModel` [PR 865](https://github.com/NatLabRockies/H2Integrate/pull/865)
 - Enable the use of latitude and longitude to specify the mine location [PR 875](https://github.com/NatLabRockies/H2Integrate/pull/875)
 - Added headroom outputs (`electricity_headroom` and `electricity_sell_headroom`) to the grid performance model. [PR #755](https://github.com/NatLabRockies/H2Integrate/pull/755)
+- Added `_check_dispatch_connections` to `H2IntegrateModel` to validate `tech_to_dispatch_connections` in the plant config against `dispatch_rule_set`/`control_strategy` declarations in the technology config, catching extraneous or missing dispatch connections at load time instead of deep inside the storage models. Also fixed a latent bug where dispatch rule connections were never wired due to an incorrect dictionary lookup, and removed unused `dispatch_rule_set` entries from examples 09 (direct ocean capture) and 11 (hybrid energy plant). [PR TBD]
 
 ## 0.9 [August 10, 2026]
 

--- a/examples/09_co2/direct_ocean_capture/tech_config.yaml
+++ b/examples/09_co2/direct_ocean_capture/tech_config.yaml
@@ -6,8 +6,6 @@ technologies:
       model: PySAMWavePerformanceModel
     cost_model:
       model: PySAMMarineCostModel
-    dispatch_rule_set:
-      model: PyomoDispatchGenericConverter
     model_inputs:
       shared_parameters:
         device_rating_kw: 286  # kW, rated power of a single wave device
@@ -63,9 +61,6 @@ technologies:
         device_spacing: 600  # meters
         row_spacing: 600  # meters
         cable_system_overbuild: 20  # percent
-      dispatch_rule_parameters:
-        commodity: electricity
-        commodity_rate_units: kW
   wind:
     performance_model:
       model: FlorisWindPlantPerformanceModel

--- a/examples/11_hybrid_energy_plant/tech_config.yaml
+++ b/examples/11_hybrid_energy_plant/tech_config.yaml
@@ -6,8 +6,6 @@ technologies:
       model: PYSAMWindPlantPerformanceModel
     cost_model:
       model: ATBWindPlantCostModel
-    dispatch_rule_set:
-      model: PyomoDispatchGenericConverter
     model_inputs:
       performance_parameters:
         num_turbines: 2
@@ -30,16 +28,11 @@ technologies:
         capex_per_kW: 1228.308  # $/kW, from 2024 ATB land-based wind class 1 moderate year 2030
         opex_per_kW_per_year: 29.2638  # $/kW/year, from 2024 ATB
         cost_year: 2022
-      dispatch_rule_parameters:
-        commodity: electricity
-        commodity_rate_units: kW
   solar:
     performance_model:
       model: PYSAMSolarPlantPerformanceModel
     cost_model:
       model: ATBUtilityPVCostModel
-    dispatch_rule_set:
-      model: PyomoDispatchGenericConverter
     model_inputs:
       performance_parameters:
         pv_capacity_kWdc: 2500.0  # kW-DC, initial value (design variable)
@@ -52,9 +45,6 @@ technologies:
         capex_per_kWac: 1043.702  # $/kW-AC, from 2024 ATB utility PV moderate year 2030
         opex_per_kWac_per_year: 17.9907  # $/kW-AC/year, from 2024 ATB
         cost_year: 2022
-      dispatch_rule_parameters:
-        commodity: electricity
-        commodity_rate_units: kW
   combiner:
     performance_model:
       model: GenericCombinerPerformanceModel

--- a/h2integrate/core/h2integrate_model.py
+++ b/h2integrate/core/h2integrate_model.py
@@ -75,6 +75,10 @@ class H2IntegrateModel:
         # they will need tech_config but not driver or plant config
         self.create_technology_models()
 
+        # validate `tech_to_dispatch_connections` against `dispatch_rule_set`/
+        # `control_strategy` declarations before building any further OpenMDAO connections
+        self._check_dispatch_connections()
+
         self.create_finance_model()
 
         # add system-level controller if configured
@@ -1111,6 +1115,135 @@ class H2IntegrateModel:
             msg = f"Model {model_name} is missing a control classifier"
             raise ValueError(msg)
 
+    def _check_dispatch_connections(self):
+        """Validate ``tech_to_dispatch_connections`` against the ``dispatch_rule_set``/
+        ``control_strategy`` declarations in the technology config.
+
+        Storage performance models and Pyomo storage controllers (subclasses of
+        ``PyomoStorageControllerBaseClass``) infer feedback-control behavior purely from
+        the *presence* of ``tech_to_dispatch_connections`` in the plant config, without
+        checking whether it is still consistent with the technology config. A common
+        source of hard-to-debug errors is leaving ``tech_to_dispatch_connections`` in
+        the plant config after switching a storage technology (and the technology feeding
+        it) from a Pyomo-based dispatch controller to an open-loop controller. This method
+        catches that mismatch early, before any OpenMDAO components are built.
+
+        Two checks are performed:
+
+        1. **Extraneous connections**: every technology named as the "dispatching"
+           technology (the second entry of each ``[tech_name, dispatching_tech_name]``
+           pair) must declare a ``dispatch_rule_set`` or use a ``control_strategy`` that
+           subclasses ``PyomoStorageControllerBaseClass``. Otherwise
+           ``tech_to_dispatch_connections`` is stale.
+        2. **Missing connections**: every technology that declares a ``dispatch_rule_set``
+           must appear in ``tech_to_dispatch_connections`` paired with the downstream
+           technology it feeds (inferred from ``technology_interconnections``).
+
+        Raises:
+            ValueError: If either check fails.
+        """
+        from h2integrate.control.control_strategies.pyomo_storage_controller_baseclass import (
+            PyomoStorageControllerBaseClass,
+        )
+
+        technologies = self.technology_config.get("technologies", {})
+        dispatch_connections = self.plant_config.get("tech_to_dispatch_connections") or []
+
+        def _has_pyomo_storage_controller(tech_name):
+            control_model_name = (
+                technologies.get(tech_name, {}).get("control_strategy", {}).get("model")
+            )
+            if control_model_name is None:
+                return False
+            control_cls = self.supported_models.get(control_model_name)
+            return control_cls is not None and issubclass(
+                control_cls, PyomoStorageControllerBaseClass
+            )
+
+        def _is_dispatch_controlled(tech_name):
+            return "dispatch_rule_set" in technologies.get(
+                tech_name, {}
+            ) or _has_pyomo_storage_controller(tech_name)
+
+        # --- Check 1: extraneous connections -------------------------------
+        if dispatch_connections:
+            invalid_dispatching_techs = sorted(
+                {
+                    connection[1]
+                    for connection in dispatch_connections
+                    if len(connection) == 2 and not _is_dispatch_controlled(connection[1])
+                }
+            )
+            if invalid_dispatching_techs:
+                plural = len(invalid_dispatching_techs) > 1
+                msg = (
+                    "`tech_to_dispatch_connections` in the plant config references "
+                    f"{invalid_dispatching_techs}, but "
+                    f"{'these technologies do' if plural else 'this technology does'} not "
+                    "declare a `dispatch_rule_set` or use a `control_strategy` that subclasses "
+                    "`PyomoStorageControllerBaseClass`. This usually happens after switching a "
+                    "storage technology to an open-loop controller without removing the "
+                    f"corresponding entries for {invalid_dispatching_techs} from "
+                    "`tech_to_dispatch_connections` in the plant config."
+                )
+                raise ValueError(msg)
+
+        # --- Check 2: missing/incorrect connections -------------------------
+        dispatch_rule_techs = sorted(
+            tech_name
+            for tech_name, tech_info in technologies.items()
+            if "dispatch_rule_set" in tech_info
+        )
+        if not dispatch_rule_techs:
+            return
+
+        existing_pairs = {
+            (connection[0], connection[1])
+            for connection in dispatch_connections
+            if len(connection) == 2
+        }
+
+        missing_techs = []
+        required_pairs_by_tech = {}
+        for tech_name in dispatch_rule_techs:
+            if _has_pyomo_storage_controller(tech_name):
+                # This technology is itself the one being dispatched (e.g. a storage
+                # tech with a Pyomo control strategy); it is registered via a self-loop.
+                required_pairs = {(tech_name, tech_name)}
+            else:
+                successors = (
+                    self.technology_graph.successors(tech_name)
+                    if tech_name in self.technology_graph
+                    else []
+                )
+                required_pairs = {
+                    (tech_name, successor)
+                    for successor in successors
+                    if _is_dispatch_controlled(successor)
+                }
+            required_pairs_by_tech[tech_name] = required_pairs
+            if not required_pairs or not required_pairs.intersection(existing_pairs):
+                missing_techs.append(tech_name)
+
+        if missing_techs:
+            plural = len(missing_techs) > 1
+            expected_connections = sorted(
+                list(pair)
+                for tech_name in missing_techs
+                for pair in required_pairs_by_tech[tech_name]
+            )
+            msg = (
+                f"Technolog{'ies' if plural else 'y'} {missing_techs} declare a "
+                "`dispatch_rule_set` but "
+                f"{'are' if plural else 'is'} missing from (or incorrectly listed in) "
+                "`tech_to_dispatch_connections` in the plant config. Based on "
+                "`technology_interconnections`, `tech_to_dispatch_connections` should include "
+                f"(at least): {expected_connections}. If a `dispatch_rule_set` is no longer "
+                "needed (e.g. after switching a storage technology to an open-loop controller), "
+                "remove it instead of adding a connection."
+            )
+            raise ValueError(msg)
+
     def _add_passthrough_controller(self, tech_group, perf_comp, individual_tech_config):
         """Automatically add a PassthroughController to a tech group if appropriate.
 
@@ -1949,8 +2082,10 @@ class H2IntegrateModel:
                 continue
             else:
                 # Only connect dispatch rules if they are defined in the tech_config
-                tech_dispatch_rule = self.technology_config.get(tech_name, {}).get(
-                    "dispatch_rule_set", False
+                tech_dispatch_rule = (
+                    self.technology_config["technologies"]
+                    .get(tech_name, {})
+                    .get("dispatch_rule_set", False)
                 )
                 if tech_dispatch_rule:
                     # Connect the dispatch rules output to the dispatching_tech_name input

--- a/h2integrate/core/test/test_framework.py
+++ b/h2integrate/core/test/test_framework.py
@@ -1376,3 +1376,165 @@ def test_create_xdsm_propagates_file_not_found_error():
     ):
         with pytest.raises(FileNotFoundError, match="latex not found"):
             model.create_xdsm()
+
+
+# ---------------------------------------------------------------------------
+# Lightweight unit tests for _check_dispatch_connections
+#
+# These bypass OpenMDAO entirely by constructing a minimal fake model object
+# carrying only the attributes the validator reads: ``technology_config``,
+# ``plant_config``, ``supported_models``, and ``technology_graph``.
+# ---------------------------------------------------------------------------
+
+
+class _FakeOpenLoopController:
+    """Stand-in for an open-loop `control_strategy` class (not Pyomo-based)."""
+
+
+def _make_dispatch_fake_model(technologies, tech_to_dispatch_connections, interconnections=None):
+    """Build a minimal stub for testing `_check_dispatch_connections`.
+
+    Args:
+        technologies (dict): value for `technology_config["technologies"]`.
+        tech_to_dispatch_connections (list | None): value for
+            `plant_config["tech_to_dispatch_connections"]`. Omitted from `plant_config`
+            entirely if ``None``.
+        interconnections (list, optional): `technology_interconnections` entries used to
+            build the technology graph. Defaults to an empty list.
+
+    Returns:
+        types.SimpleNamespace: stub with `technology_config`, `plant_config`,
+            `supported_models`, and `technology_graph` set.
+    """
+    from h2integrate.control.control_strategies.pyomo_storage_controller_baseclass import (
+        PyomoStorageControllerBaseClass,
+    )
+
+    class _FakePyomoStorageController(PyomoStorageControllerBaseClass):
+        pass
+
+    fake = types.SimpleNamespace()
+    fake.technology_config = {"technologies": technologies}
+    plant_config = {}
+    if tech_to_dispatch_connections is not None:
+        plant_config["tech_to_dispatch_connections"] = tech_to_dispatch_connections
+    fake.plant_config = plant_config
+    fake.supported_models = {
+        "PyomoStorageController": _FakePyomoStorageController,
+        "OpenLoopController": _FakeOpenLoopController,
+    }
+    fake.technology_graph = H2IntegrateModel.create_technology_graph(fake, interconnections or [])
+    return fake
+
+
+@pytest.mark.unit
+def test_check_dispatch_connections_valid_heuristic_style_passes():
+    """combiner (dispatch_rule_set) -> battery (dispatch_rule_set + Pyomo controller),
+    both registered in `tech_to_dispatch_connections`, must not raise."""
+    technologies = {
+        "combiner": {"dispatch_rule_set": {"model": "PyomoDispatchGenericConverter"}},
+        "battery": {
+            "dispatch_rule_set": {"model": "PyomoRuleStorageBaseclass"},
+            "control_strategy": {"model": "PyomoStorageController"},
+        },
+    }
+    interconnections = [["combiner", "battery", "electricity", "cable"]]
+    fake = _make_dispatch_fake_model(
+        technologies,
+        [["combiner", "battery"], ["battery", "battery"]],
+        interconnections,
+    )
+    H2IntegrateModel._check_dispatch_connections(fake)  # must not raise
+
+
+@pytest.mark.unit
+def test_check_dispatch_connections_valid_standalone_pyomo_controller_passes():
+    """A Pyomo storage controller that needs no `dispatch_rule_set` anywhere (e.g.
+    optimization-based controllers) is valid as long as it is listed."""
+    technologies = {
+        "feedstock": {"performance_model": {"model": "FeedstockPerformanceModel"}},
+        "battery": {"control_strategy": {"model": "PyomoStorageController"}},
+    }
+    fake = _make_dispatch_fake_model(
+        technologies,
+        [["feedstock", "battery"], ["battery", "battery"]],
+    )
+    H2IntegrateModel._check_dispatch_connections(fake)  # must not raise
+
+
+@pytest.mark.unit
+def test_check_dispatch_connections_no_op_when_key_absent():
+    """No `tech_to_dispatch_connections` and no `dispatch_rule_set` should be a no-op."""
+    technologies = {"wind": {"performance_model": {"model": "SomeWindModel"}}}
+    fake = _make_dispatch_fake_model(technologies, None)
+    H2IntegrateModel._check_dispatch_connections(fake)  # must not raise
+
+
+@pytest.mark.unit
+def test_check_dispatch_connections_extraneous_raises():
+    """A dispatching tech using an open-loop controller (no `dispatch_rule_set`, no Pyomo
+    `control_strategy`) left over in `tech_to_dispatch_connections` must raise."""
+    technologies = {
+        "combiner": {"dispatch_rule_set": {"model": "PyomoDispatchGenericConverter"}},
+        "battery": {"control_strategy": {"model": "OpenLoopController"}},
+    }
+    interconnections = [["combiner", "battery", "electricity", "cable"]]
+    fake = _make_dispatch_fake_model(
+        technologies,
+        [["combiner", "battery"], ["battery", "battery"]],
+        interconnections,
+    )
+    with pytest.raises(ValueError) as excinfo:
+        H2IntegrateModel._check_dispatch_connections(fake)
+    err = str(excinfo.value)
+    assert "battery" in err
+    assert "tech_to_dispatch_connections" in err
+
+
+@pytest.mark.unit
+def test_check_dispatch_connections_missing_raises():
+    """A technology declaring `dispatch_rule_set` but missing from
+    `tech_to_dispatch_connections` must raise and suggest the expected connection."""
+    technologies = {
+        "combiner": {"dispatch_rule_set": {"model": "PyomoDispatchGenericConverter"}},
+        "battery": {
+            "dispatch_rule_set": {"model": "PyomoRuleStorageBaseclass"},
+            "control_strategy": {"model": "PyomoStorageController"},
+        },
+    }
+    interconnections = [["combiner", "battery", "electricity", "cable"]]
+    fake = _make_dispatch_fake_model(
+        technologies,
+        [["battery", "battery"]],  # missing the [combiner, battery] entry
+        interconnections,
+    )
+    with pytest.raises(ValueError) as excinfo:
+        H2IntegrateModel._check_dispatch_connections(fake)
+    err = str(excinfo.value)
+    assert "combiner" in err
+    assert "['combiner', 'battery']" in err
+
+
+@pytest.mark.unit
+def test_check_dispatch_connections_missing_key_entirely_raises():
+    """A technology declaring `dispatch_rule_set` with `tech_to_dispatch_connections`
+    missing entirely from the plant config must also raise."""
+    technologies = {
+        "wave": {"dispatch_rule_set": {"model": "PyomoDispatchGenericConverter"}},
+        "combiner": {"dispatch_rule_set": {"model": "PyomoDispatchGenericConverter"}},
+        "battery": {
+            "dispatch_rule_set": {"model": "PyomoRuleStorageBaseclass"},
+            "control_strategy": {"model": "PyomoStorageController"},
+        },
+    }
+    interconnections = [
+        ["wave", "combiner", "electricity", "cable"],
+        ["combiner", "battery", "electricity", "cable"],
+    ]
+    fake = _make_dispatch_fake_model(technologies, None, interconnections)
+    with pytest.raises(ValueError) as excinfo:
+        H2IntegrateModel._check_dispatch_connections(fake)
+    err = str(excinfo.value)
+    assert "wave" in err
+    assert "combiner" in err
+    assert "battery" in err


### PR DESCRIPTION
# Check for extraneous and missing `tech_to_dispatch_connections`

This PR adds configuration validation to check for extraneous or missing `tech_to_dispatch_connections` between the plant and technology configurations:
1. When `tech_to_dispatch_connections` is specified in `plant_config`, verifies that connected technologies include `dispatch_rule_set` or utilize a Pyomo storage controller, raising a helpful error if open-loop controllers are used without dispatch rules.
2. When technologies define `dispatch_rule_set`, verifies that `tech_to_dispatch_connections` is present and correctly structured, inferring expected connections from `technology_interconnections` when reporting errors.

## Section 1: Type of Contribution
- [x] Feature Enhancement
  - [x] Framework
  - [ ] New Model
  - [ ] Updated Model
  - [x] Tools/Utilities
  - [ ] Other (please describe):
- [x] Bug Fix
- [ ] Documentation Update
- [ ] CI Changes
- [ ] Other (please describe):

## Section 2: Draft PR Checklist
- [x] Open draft PR
- [x] Describe the feature that will be added
- [x] Fill out TODO list steps
- [ ] Describe requested feedback from reviewers on draft PR
- [ ] Complete Section 8: New Model Checklist (if applicable)

### TODO:
- [x] Add dispatch connection checker utility function
- [x] Integrate checker into H2IntegrateModel configuration loading
- [x] Add comprehensive unit tests for validation cases

### Type of Reviewer Feedback Requested (on Draft PR)
**Structural feedback**:

**Implementation feedback**:

**Other feedback**:

## Section 3: General PR Checklist
- [x] PR description thoroughly describes the new feature, bug fix, etc.
- [x] Added tests for new functionality or bug fixes
- [x] Tests pass (If not, and this is expected, please elaborate in the Section 6: Test Results)
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [ ] Related docs/ files are up-to-date, or added when necessary
  - [ ] Documentation has been rebuilt successfully
  - [x] Examples have been updated (if applicable)
- [x] CHANGELOG.md
  - [x] At least one complete sentence has been provided to describe the changes made in this PR
  - [x] After the above, a hyperlink has been provided to the PR using the following format:
    "A complete thought. [PR XYZ]((https://github.com/NatLabRockies/H2Integrate/pull/XYZ)", where
    `XYZ` should be replaced with the actual number.

## Section 4: Related Issues
- Closes #848
- Made #883
## Section 5: Impacted Areas of the Software
### Section 5.1: New Files
- N/A

### Section 5.2: Modified Files
- `h2integrate/core/h2integrate_model.py`
  - Added `_check_dispatch_connections`, invoked in `__init__` right after `create_technology_models()` (so it runs before any dispatch-related OpenMDAO connections are made).
  - Fixed a latent bug in `connect_technologies()` where `dispatch_rule_set` lookups used `self.technology_config.get(tech_name, ...)` instead of `self.technology_config["technologies"].get(tech_name, ...)`, which meant dispatch rule connections were never actually wired.
- `h2integrate/core/test/test_framework.py`
  - Added lightweight stub-based unit tests for `_check_dispatch_connections` covering valid heuristic-style and standalone-Pyomo-controller configs, a no-op case, an extraneous-connection error, and two missing-connection error cases.
- `examples/09_co2/direct_ocean_capture/tech_config.yaml`
  - Removed the unused `dispatch_rule_set`/`dispatch_rule_parameters` on the `wave` technology (it fed `combiner`, not the storage tech directly, so it was never wired).
- `examples/11_hybrid_energy_plant/tech_config.yaml`
  - Removed the unused `dispatch_rule_set`/`dispatch_rule_parameters` on the `wind` and `solar` technologies (same reason as above).

## Section 6: Additional Supporting Information
N/A

## Section 7: Test Results, if applicable
New and existing tests pass

## Section 8 (Optional): New Model Checklist
N/A
